### PR TITLE
Add article type flag when the article is a review

### DIFF
--- a/src/app/views/sources/summary/sourcesSummary.tpl.html
+++ b/src/app/views/sources/summary/sourcesSummary.tpl.html
@@ -58,6 +58,12 @@
                   <span ng-bind="vm.source.status"> Source Status</span>
                 </td>
               </tr>
+              <tr ng-if="vm.source.is_review">
+                <td class="key">Article Type:</td>
+                <td class="value">
+                  <span class="label label-warning" nf-if="vm.source.is_review">Review</span>
+                </td>
+              </tr>
             </table>
 
           </div>


### PR DESCRIPTION
As per genome/civic-server#328, we're now scraping when an article is a review; this PR adds a field to the source view that displays a conditional flag when the source is in fact a review. It looks like this: 

![screen shot 2017-05-31 at 3 15 57 pm](https://cloud.githubusercontent.com/assets/13370/26652045/31aa8222-4614-11e7-91fb-10d3927c2e21.png)
