### PR TITLE
Add clinical trial IDs to the source and evidence item summaries

### DIFF
--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -113,6 +113,20 @@
             </a>
           </td>
         </tr>
+        <tr ng-if="evidence.source.clinical_trials.length > 0">
+          <td class="name">Clinical Trial<span
+              ng-if="evidence.source.clinical_trials.length > 1">s</span>:</td>
+          <td class="value">
+            <span ng-repeat="trial in evidence.source.clinical_trials">
+              {{
+              $first ? '' : $last ? (
+              evidence.source.clinical_trials.length > 2 ? ', and ' : ' and '
+              ) : ', '
+              }}
+              <a ng-href="{{trial.clinical_trial_url}}" target="_blank">{{trial.nct_id}}</a>
+            </span>
+          </td>
+        </tr>
         <tr>
           <td class="name">Trust Rating:</td>
           <td class="value">

--- a/src/app/views/sources/summary/sourcesSummary.tpl.html
+++ b/src/app/views/sources/summary/sourcesSummary.tpl.html
@@ -48,6 +48,20 @@
                   </a>
                 </td>
               </tr>
+              <tr ng-if="vm.source.clinical_trials.length > 0">
+                <td class="key">Clinical Trial<span
+                    ng-if="vm.source.clinical_trials.length > 1">s</span>:</td>
+                <td class="value">
+                  <span ng-repeat="trial in vm.source.clinical_trials">
+                    {{
+                    $first ? '' : $last ? (
+                    vm.source.clinical_trials.length > 2 ? ', and ' : ' and '
+                    ) : ', '
+                    }}
+                    <a ng-href="{{trial.clinical_trial_url}}" target="_blank">{{trial.nct_id}}</a>
+                  </span>
+                </td>
+              </tr>
               <tr>
                 <td class="key">Journal:</td>
                 <td class="value" ng-bind="vm.source.full_journal_title ? vm.source.full_journal_title : vm.source.journal"></td>


### PR DESCRIPTION
This is needed for https://github.com/griffithlab/civic-server/issues/334. The server changes necessary for this to work are at https://github.com/griffithlab/civic-server/pull/369. 

Since this field isn't populated for all sources, I only display it conditionally. This results in the evidence item summary looking a bit lopsided because there is more content in the right column than in the left if a clinical trial ID is present.