### PR TITLE
Add CIViC variant score to variant summary

### DIFF
--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -113,6 +113,11 @@
               </span>
             </p>
           </div>
+          <div class="civic-variant-score">
+            <p>
+              <strong>CIViC Variant Score: </strong>{{variant.civic_actionability_score}}
+            </p>
+          </div>
         </div>
         <div class="col-xs-12 col-md-6">
           <div ng-if="variant.sources.length > 0">

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -115,7 +115,8 @@
           </div>
           <div class="civic-variant-score">
             <p>
-              <strong>CIViC Variant Score: </strong>{{variant.civic_actionability_score}}
+              <strong>CIViC Variant Score: </strong><br/>
+              {{variant.civic_actionability_score}}
             </p>
           </div>
         </div>


### PR DESCRIPTION
This PR adds the CIViC variant score to the variant summary. It doesn't look fancy but gets the job done.

This PR depends on https://github.com/griffithlab/civic-server/pull/364