### PR TITLE
fixed templateUrl path - was not matching path used by the template cache

### DIFF
--- a/src/components/forms/fieldTypes/comment.js
+++ b/src/components/forms/fieldTypes/comment.js
@@ -8,7 +8,7 @@
     var _ = window._;
     formlyConfigProvider.setType({
       name: 'comment',
-      templateUrl: 'src/components/forms/fieldTypes/comment.tpl.html',
+      templateUrl: 'components/forms/fieldTypes/comment.tpl.html',
       defaultOptions: {
         ngModelAttrs: {
           rows: {attribute: 'rows'},


### PR DESCRIPTION
This fixes the missing comment textarea bug.