### PR TITLE
added static maintenance page

### DIFF
--- a/src/index_maintenance.html
+++ b/src/index_maintenance.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html class="no-js" ng-app="civicClient">
+  <head>
+    <title ng-bind="title">CIViC - Clinical Interpretations of Variants in Cancer</title>
+    <meta charset="utf-8">
+  </head>
+  <body style="background-color: #222;">
+    <div style="text-align: center; padding-top: 100px; padding-bottom: 25px;">
+      <img src="assets/images/preloader_logo_v1.png"/>
+    </div>
+    <div style="font-family: Helvetica, Arial, sans-serif; text-align: center" >
+      <h1 style="color: #FEF">CIViC is currently undergoing maintenance.</h1>
+    </div>
+
+    <div style="font-family: Helvetica, Arial, sans-serif; margin: 20px auto; width: 500px; color: #FEF" >
+      <p>We're moving the site to a new server, and anticipate that it make take [MAINTENENACE TIME ESTIMATE] to complete.</p>
+
+      <p>We started the move at [START TIME]CST, so please check back after [END TIME]CST and reload the application.</p>
+      <p>Thank you for your interest in CIViC and your patience with our mainenance.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Added the page 'index_maintenance.html' to the server root, this can be used (after filling in the maintenance times and estimate) to notify users about site maintenance, and when they can expect the service to return.

This page only loads in the civic logo from the assets directory, otherwise it is self-contained.