### PR TITLE
switched CDN for angular-translate, previous did not have all available versions

### DIFF
--- a/gulp/cdnize.js
+++ b/gulp/cdnize.js
@@ -98,7 +98,7 @@ gulp.task('cdnize', ['inject'], function () {
       {
         file: '**/angular-translate/*.js',
         package: 'angular-translate',
-        cdn: '//cdn.jsdelivr.net/angular.translate/${ version }/${ filenameMin }',
+        cdn: '//cdnjs.cloudflare.com/ajax/libs/angular-translate/${ version }/${ filenameMin }',
         test: 'testModule("pascalprecht.translate")'
       },
       {


### PR DESCRIPTION
bower library version calculation at build-time is apparently not deterministic as it produces different version numbers on different workstations. The CDN used for the angular-translate dependency didn't have the version that was sometimes calculated. This update switches to a CDN that has all available versions for angular-translate, so we shouldn't run into the intermittent 404 error in the future.