### PR TITLE
added simple sorting select for assertion evidence card display

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -841,7 +841,7 @@
             geneId: row.entity.gene_id,
             variantId: row.entity.variant_id,
             evidenceId: row.entity.id,
-            '#': 'variant'
+            '#': 'evidence'
           };
         }
 

--- a/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
+++ b/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
@@ -102,8 +102,8 @@
                         }}
                         {{ code.code}}
                       </span>
-                    </span>
-                    <span ng-switch-when="false">
+                  </span>
+                  <span ng-switch-when="false">
                       --
                     </span>
                   </span>
@@ -118,8 +118,8 @@
                     <span ng-switch-when="true">
                       {{ vm.assertion.nccn_guideline }}
                       <span ng-if="vm.assertion.nccn_guideline_version">(v{{vm.assertion.nccn_guideline_version}})</span>
-                    </span>
-                    <span ng-switch-when="false">
+                  </span>
+                  <span ng-switch-when="false">
                       --
                     </span>
                   </span>
@@ -132,7 +132,7 @@
                     <span ng-switch-when="true" >
                       <i class="glyphicon glyphicon-ok" style="color: green"></i>
                     </span>
-                    <span ng-switch-when="false">
+                  <span ng-switch-when="false">
                       --
                     </span>
                   </span>
@@ -185,12 +185,30 @@
         </uib-tab>
         <uib-tab index="1" heading="Evidence Cards">
           <div class="itemContainer">
-            <h4>Evidence Supporting AID{{vm.assertion.id}} <span class="record-info" >{{vm.assertion.evidence_items.length}} total items</span></h4>
-            <ul class="evidenceSelectorItems">
-              <li ng-repeat="item in vm.assertion.evidence_items">
-                <evidence-selector-item item="item" remove-fn="removeItem"></evidence-selector-item>
-              </li>
-            </ul>
+            <div class="row">
+              <div class="col-xs-7">
+                <h4>Evidence Supporting AID{{vm.assertion.id}} <span class="record-info" >{{vm.assertion.evidence_items.length}} total items</span></h4>
+              </div>
+              <div class="col-xs-2" style="text-align: right; padding-top: 6px;">
+                <label for="orderBy">Order by:</label>
+              </div>
+              <div class="col-xs-3" style="padding-bottom: 6px;">
+                <select class="form-control" id="orderBy" ng-model="order_by" ng-init="order_by = 'evidence_level'">
+                  <option value="id">ID</option>
+                  <option value="rating">Rating</option>
+                  <option value="evidence_level">Evidence Level</option>
+                </select>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-xs-12">
+                <ul class="evidenceSelectorItems">
+                  <li ng-repeat="item in vm.assertion.evidence_items | orderBy: order_by">
+                    <evidence-selector-item item="item" remove-fn="removeItem"></evidence-selector-item>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
         </uib-tab>
       </uib-tabset>

--- a/src/app/views/events/evidence/summary/evidenceSummary.js
+++ b/src/app/views/events/evidence/summary/evidenceSummary.js
@@ -50,11 +50,10 @@
         $scope.evidence.drugsStr = '--';
       }
       if($scope.evidence.phenotypes.length > 0) {
-        var hpoUrl = ConfigService.hpoUrl;
         $scope.evidence.phenotypesStr = _.chain($scope.evidence.phenotypes)
           .sortBy('hpo_class')
           .map(function(item) {
-            return '<a href="' + hpoUrl + item.hpo_id + '" target="_blank">' + item.hpo_class + '</a>';
+            return '<a href="' + item.url + '" target="_blank">' + item.hpo_class + '</a>';
           })
           .value()
           .join(', ');

--- a/src/app/views/events/evidence/summary/evidenceSummary.js
+++ b/src/app/views/events/evidence/summary/evidenceSummary.js
@@ -50,7 +50,14 @@
         $scope.evidence.drugsStr = '--';
       }
       if($scope.evidence.phenotypes.length > 0) {
-        $scope.evidence.phenotypesStr = _.chain($scope.evidence.phenotypes).map('hpo_class').sort().value().join(', ');
+        var hpoUrl = ConfigService.hpoUrl;
+        $scope.evidence.phenotypesStr = _.chain($scope.evidence.phenotypes)
+          .sortBy('hpo_class')
+          .map(function(item) {
+            return '<a href="' + hpoUrl + item.hpo_id + '" target="_blank">' + item.hpo_class + '</a>';
+          })
+          .value()
+          .join(', ');
       } else {
         $scope.evidence.phenotypesStr = '--';
       }

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -71,11 +71,9 @@
         </tr>
         <tr ng-if="evidence.evidence_type == 'Predictive'">
           <td class="name">Drug:</td>
-          <td class="value">{{ evidence.drugsStr }}</td>
-        </tr>
-        <tr ng-show="evidence.drug_interaction_type">
-          <td class="name">Drug Interaction:</td>
-          <td class="value">{{ evidence.drug_interaction_type }}</td>
+          <td class="value">
+            {{ evidence.drugsStr }}<span ng-if="evidence.drug_interaction_type">&nbsp;({{ evidence.drug_interaction_type }})</span>
+          </td>
         </tr>
       </table>
     </div>

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -94,7 +94,7 @@
         </tr>
         <tr>
           <td class="name">Associated Phenotype{{ evidence.phenotypes.length > 1 ? 's' : '' }}:</td>
-          <td class="value">{{ evidence.phenotypesStr }}</td>
+          <td class="value" ng-bind-html="evidence.phenotypesStr"></td>
         </tr>
         <tr>
           <td class="name">Citation:</td>

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -15,10 +15,10 @@
           <td class="name" style="line-height: 2em;">Evidence Level:</td>
           <td class="value">
             <span class="levelBadge"
-                  ng-class="{'levelA': evidence.evidence_level === 'A', 'levelB': evidence.evidence_level === 'B','levelC': evidence.evidence_level === 'C', 'levelD': evidence.evidence_level === 'D', 'levelE': evidence.evidence_level === 'E' }"
-                  uib-tooltip="{{tipText.evidence_level[evidence.evidence_level]}}"
-                  tooltip-placement="right"
-                  class="help-tooltip">
+              ng-class="{'levelA': evidence.evidence_level === 'A', 'levelB': evidence.evidence_level === 'B','levelC': evidence.evidence_level === 'C', 'levelD': evidence.evidence_level === 'D', 'levelE': evidence.evidence_level === 'E' }"
+              uib-tooltip="{{tipText.evidence_level[evidence.evidence_level]}}"
+              tooltip-placement="right"
+              class="help-tooltip">
               {{ evidence.evidence_level_string }}
             </span>
           </td>
@@ -27,9 +27,9 @@
           <td class="name">Evidence Type:</td>
           <td class="value">
             <span ng-bind="evidence.evidence_type"
-                  uib-tooltip="{{tipText.evidence_type[evidence.evidence_type]}}"
-                  tooltip-placement="right"
-                  class="help-tooltip">
+              uib-tooltip="{{tipText.evidence_type[evidence.evidence_type]}}"
+              tooltip-placement="right"
+              class="help-tooltip">
               evidence type</span>
           </td>
         </tr>
@@ -37,9 +37,9 @@
           <td class="name">Evidence Direction:</td>
           <td class="value">
             <span ng-bind="evidence.evidence_direction"
-                  uib-tooltip="{{tipText.evidence_direction[evidence.evidence_type][evidence.evidence_direction]}}"
-                  tooltip-placement="right"
-                  class="help-tooltip">
+              uib-tooltip="{{tipText.evidence_direction[evidence.evidence_type][evidence.evidence_direction]}}"
+              tooltip-placement="right"
+              class="help-tooltip">
               evidence.evidence_direction
             </span>
           </td>
@@ -49,10 +49,10 @@
           <td class="name">Clinical Significance:</td>
           <td class="value">
             <span ng-bind="evidence.clinical_significance"
-                  uib-tooltip="{{tipText.clinical_significance[evidence.evidence_type][evidence.clinical_significance]}}"
-                  tooltip-placement="right"
-                  class="help-tooltip"
-                  class="help-tooltip">
+              uib-tooltip="{{tipText.clinical_significance[evidence.evidence_type][evidence.clinical_significance]}}"
+              tooltip-placement="right"
+              class="help-tooltip"
+              class="help-tooltip">
               evidence.clinical_significance
             </span>
           </td>
@@ -62,9 +62,9 @@
           <td class="name">Variant Origin:</td>
           <td class="value">
             <span ng-bind="evidence.variant_origin"
-                  uib-tooltip="{{tipText.variant_origin[evidence.variant_origin]}}"
-                  tooltip-placement="right"
-                  class="help-tooltip">
+              uib-tooltip="{{tipText.variant_origin[evidence.variant_origin]}}"
+              tooltip-placement="right"
+              class="help-tooltip">
               evidence.variant_origin
             </span>
           </td>
@@ -73,6 +73,15 @@
           <td class="name">Drug:</td>
           <td class="value">
             {{ evidence.drugsStr }}<span ng-if="evidence.drug_interaction_type">&nbsp;({{ evidence.drug_interaction_type }})</span>
+          </td>
+        </tr>
+        <tr ng-if="evidence.assertions.length > 0">
+          <td class="name" style="padding-top: 5px;padding-bottom: 0;">
+            Supports Assertions:
+          </td>
+          <td class="value assertions">
+            <assertion-tag ng-repeat="assertion in evidence.assertions | orderBy:'id'" ng-show="assertion.status !== 'rejected' || showAll === true" assertion="assertion">
+            </assertion-tag>
           </td>
         </tr>
       </table>
@@ -108,8 +117,8 @@
           <td class="name">Pubmed ID:</td>
           <td class="value">
             <a ng-href="http://www.ncbi.nlm.nih.gov/pubmed/{{evidence.source.pubmed_id}}"
-               class="btn btn-xs button-new-window"
-               target="_blank">
+              class="btn btn-xs button-new-window"
+              target="_blank">
               <span class="glyphicon glyphicon-new-window"></span>
               <span ng-bind="evidence.source.pubmed_id"></span>
             </a>
@@ -124,12 +133,12 @@
               evidence.source.clinical_trials.length > 2 ? ' and ' : ' and '
               ) : ' '
               }}
-            <a ng-href="{{trial.clinical_trial_url}}"
-               class="btn btn-xs button-new-window" style="margin-bottom: 4px;"
-               target="_blank">
-              <span class="glyphicon glyphicon-new-window"></span>
-              <span ng-bind="trial.nct_id"></span>
-            </a>
+              <a ng-href="{{trial.clinical_trial_url}}"
+                class="btn btn-xs button-new-window" style="margin-bottom: 4px;"
+                target="_blank">
+                <span class="glyphicon glyphicon-new-window"></span>
+                <span ng-bind="trial.nct_id"></span>
+              </a>
             </span>
             <span ng-if="evidence.source.clinical_trials.length == 0">--</span>
           </td>
@@ -138,9 +147,9 @@
           <td class="name">Trust Rating:</td>
           <td class="value">
             <span uib-rating ng-model="evidence.rating" max="5" read-only="true"
-                    uib-tooltip="{{tipText.rating[evidence.rating]}}"
-                    tooltip-placement="left"
-                    class="help-tooltip">
+              uib-tooltip="{{tipText.rating[evidence.rating]}}"
+              tooltip-placement="left"
+              class="help-tooltip">
             </span>
           </td>
         </tr>
@@ -150,21 +159,21 @@
   <div class="row" ng-if="(isEditor() || isAdmin()) && evidence.status === 'submitted'" style="margin-top: 1em;">
     <div class="col-xs-6">
       <button class="btn btn-default btn-block btn-danger"
-              ng-click="rejectItem(evidence.id)">
+        ng-click="rejectItem(evidence.id)">
         Reject Evidence Item
       </button>
     </div>
     <div class="col-xs-6">
       <span uib-tooltip="Contributors may not accept their own submissions."
-            tooltip-append-to-body="true"
-            tooltip-enable="ownerIsCurrentUser"
-            class="help-tooltip">
-      <button class="btn btn-default btn-block btn-success"
-              ng-disabled="ownerIsCurrentUser"
-              ng-click="acceptItem(evidence.id)">
-        Accept Evidence Item
-      </button>
-        </span>
+        tooltip-append-to-body="true"
+        tooltip-enable="ownerIsCurrentUser"
+        class="help-tooltip">
+        <button class="btn btn-default btn-block btn-success"
+          ng-disabled="ownerIsCurrentUser"
+          ng-click="acceptItem(evidence.id)">
+          Accept Evidence Item
+        </button>
+      </span>
     </div>
   </div>
   <!--<div class="row">-->

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -69,7 +69,7 @@
             </span>
           </td>
         </tr>
-        <tr>
+        <tr ng-if="evidence.evidence_type == 'Predictive'">
           <td class="name">Drug:</td>
           <td class="value">{{ evidence.drugsStr }}</td>
         </tr>

--- a/src/app/views/events/variants/summary/variantSummary.less
+++ b/src/app/views/events/variants/summary/variantSummary.less
@@ -3,9 +3,6 @@
 @import 'src/app/styles/_civic-variables.less';
 @import 'src/app/styles/_mixins.less';
 
-@tabPaddingH: .5em;
-@tabPaddingV: .25em;
-
 .variantSummary {
   padding-top: @contentPadding;
   .evidence-view {
@@ -34,11 +31,6 @@
 
     .table {
       margin: 0;
-
-      //.common tr:last-child td {
-      //  border-bottom: 1px solid #AAA;
-      //}
-
     }
 
     .key {
@@ -77,78 +69,5 @@
     list-style: none;
     margin-left: @contentPadding;
     padding: 0;
-  }
-
-  .assertions {
-    ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      padding-bottom: @contentPadding/2;
-
-      li {
-        display: inline-block;
-        margin-top: @contentPadding/2;
-        margin-right: @contentPadding/2;
-        .assertion-tag {
-          display: block;
-          text-decoration: none;
-          padding: @tabPaddingV @tabPaddingH;
-          border-radius: @border-radius-base;
-          background-color: @pageBackground2;
-          border: 1px solid @pageBackground3;
-
-          &:hover, &.active {
-            border-color: @civicPurple;
-            .variant-name {
-              color: @civicPurple;
-            }
-          }
-          .pending-alert {
-            text-shadow:
-            -1px -1px 0 #FFF,
-            1px -1px 0 #FFF,
-            -1px 1px 0 #FFF,
-            1px 1px 0 #FFF !important;
-          }
-          .pending-changes {
-            color: lighten(@civicPurple, 30%) !important;
-          }
-          .pending-evidence {
-            color: #F68F37;
-          }
-          .pending-both {
-            color: @civicRed !important;
-          }
-          &.active {
-            background-color: lighten(@civicPurple, 70%);
-            .variant-name {
-              // font-weight: bold;
-            }
-          }
-
-          &.statusRejected {
-            background-color: #ECA2C0 !important;
-            color: #47161C !important;
-            // border-color: #47161C !important;
-          }
-
-          &.statusAccepted {
-            background-color: #B2D49C !important;
-            color: #144522 !important;
-            // border-color: #144522 !important;
-          }
-
-          &.statusSubmitted {
-            background-color: #F3BC94 !important;
-            color: #4A2B11 !important;
-            // border-color: #4A2B11 !important;
-          }
-        }
-
-        a.active {
-        }
-      }
-    }
   }
 }

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -4,8 +4,7 @@
       <div class="row">
         <div class="col-xs-12">
           <div class="row">
-            <div ng-if="variant.variant_aliases.length > 0"
-              ng-class="{'col-xs-7': variant.allele_registry_id !== null, 'col-xs-12': variant.allele_registry_id === null }">
+            <div ng-if="variant.variant_aliases.length > 0" ng-class="{'col-xs-7': variant.allele_registry_id !== null, 'col-xs-12': variant.allele_registry_id === null }">
               <p><strong>Aliases: </strong>
                 <span ng-repeat="alias in variant.variant_aliases">
                   {{
@@ -17,15 +16,14 @@
                 </span>
               </p>
             </div>
-            <div ng-if="variant.allele_registry_id !== null"
-              ng-class="{'col-xs-5': variant.allele_registry_id !== null , 'col-xs-12': variant.variant_aliases.length === 0 }">
+            <div ng-if="variant.allele_registry_id !== null" ng-class="{'col-xs-5': variant.allele_registry_id !== null , 'col-xs-12': variant.variant_aliases.length === 0 }">
               <p><strong>Allele Registry ID: </strong> <a ng-href="https://reg.genome.network/allele/{{variant.allele_registry_id}}.html" target="_blank">{{variant.allele_registry_id}}</a></p>
             </div>
           </div>
         </div>
       </div>
-      <div class="row" >
-        <div class="col-xs-12" >
+      <div class="row">
+        <div class="col-xs-12">
           <div ng-switch="variant.description.length > 0">
             <div ng-switch-when="true">
               <p ng-bind="variant.description" class="description">
@@ -51,7 +49,8 @@
         <div class="col-xs-12 col-md-6">
           <div class="variant-types">
             <p>
-              <strong>Variant Type<span ng-if="variant.variant_types.length > 1">s</span>:</strong><br/>
+              <strong>Variant Type<span ng-if="variant.variant_types.length > 1">s</span>:</strong>
+              <br/>
               <span ng-switch="variant.variant_types.length > 0">
                 <span ng-switch-when="true">
                   <span ng-repeat="type in variant.variant_types">
@@ -63,10 +62,10 @@
                     <span  ng-if="type.display_name !== 'N/A'">
                       <a ng-href="{{ type.url }}" target="_blank">{{type.display_name}}</a>
                     </span>
-                    <span ng-if="type.display_name === 'N/A'">{{type.display_name}}</span>
-                  </span>
-                </span>
-                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+              <span ng-if="type.display_name === 'N/A'">{{type.display_name}}</span>
+              </span>
+              </span>
+              <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
               </span>
@@ -74,7 +73,8 @@
           </div>
           <div class="hgvs-expressions">
             <p>
-              <strong>HGVS Expression<span ng-if="variant.hgvs_expressions.length > 1">s</span>:</strong><br/>
+              <strong>HGVS Expression<span ng-if="variant.hgvs_expressions.length > 1">s</span>:</strong>
+              <br/>
               <span ng-switch="variant.hgvs_expressions.length > 0">
                 <span ng-switch-when="true">
                   <span ng-repeat="expression in variant.hgvs_expressions" class="small">
@@ -85,8 +85,8 @@
                     }}
                     {{ expression }}
                   </span>
-                </span>
-                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+              </span>
+              <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
               </span>
@@ -94,7 +94,8 @@
           </div>
           <div class="clinvar-ids">
             <p>
-              <strong>ClinVar ID<span ng-if="variant.clinvar_entries.length > 1">s</span>:</strong><br/>
+              <strong>ClinVar ID<span ng-if="variant.clinvar_entries.length > 1">s</span>:</strong>
+              <br/>
               <span ng-switch="variant.clinvar_entries.length > 0">
                 <span ng-switch-when="true">
                   <span ng-repeat="clinvar_id in variant.clinvar_entries" class="small">
@@ -105,9 +106,9 @@
                     }}
                     <a ng-if="clinvar_ignore.indexOf(clinvar_id) == -1" ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{ clinvar_id }}/" target="_blank">{{ clinvar_id }}</a>
                     <span ng-if="clinvar_ignore.indexOf(clinvar_id) !== -1">{{ clinvar_id }}</span>
-                  </span>
-                </span>
-                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+              </span>
+              </span>
+              <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
               </span>
@@ -115,8 +116,8 @@
           </div>
           <div class="civic-variant-score">
             <p>
-              <strong>CIViC Actionability Score: </strong><br/>
-              {{variant.civic_actionability_score | ifEmpty: '--' }}
+              <strong>CIViC Actionability Score: </strong>
+              <br/> {{variant.civic_actionability_score | ifEmpty: '--' }}
             </p>
           </div>
         </div>
@@ -130,19 +131,18 @@
             </ul>
           </div>
           <div class="row" ng-if="variant.assertions.length > 0">
-            <div class="col-xs-12" >
-              <div class="assertions" >
+            <div class="col-xs-12">
+              <div class="assertions">
                 <strong>Assertions:</strong>
                 <br/>
-                <ul>
-                  <li ng-repeat="assertion in variant.assertions | orderBy:'id'"
-                    ng-show="assertion.status !== 'rejected' || showAll === true">
-                    <ng-include src="'assertionTag.tpl.html'"></ng-include>
-                  </li>
-                </ul>
+                <div style="padding-top: 8px;">
+                  <assertion-tag ng-repeat="assertion in variant.assertions | orderBy:'id'" ng-show="assertion.status !== 'rejected' || showAll === true" assertion="assertion">
+                  </assertion-tag>
+                </div>
               </div>
               <div ng-show="hasHiddenAssertions" class="small">
-                <span>Show&nbsp;rejected:</span>&nbsp;&nbsp;<input type="checkbox" id="showAll" ng-model="showAll">
+                <span>Show&nbsp;rejected:</span>&nbsp;&nbsp;
+                <input type="checkbox" id="showAll" ng-model="showAll">
               </div>
 
             </div>
@@ -154,8 +154,7 @@
     <div class="col-xs-12 col-md-5">
       <div class="coordinates-block">
         <div class="section-title first">
-          Ref. Build: <span class="val">{{ variant.coordinates.reference_build | ifEmpty: '--' }}</span>&nbsp;&nbsp;
-          Ensembl Version: <span class="val">{{ variant.coordinates.ensembl_version| ifEmpty: '--' }}</span>
+          Ref. Build: <span class="val">{{ variant.coordinates.reference_build | ifEmpty: '--' }}</span>&nbsp;&nbsp; Ensembl Version: <span class="val">{{ variant.coordinates.ensembl_version| ifEmpty: '--' }}</span>
         </div>
         <table class="table table-condensed borderless">
           <tbody class="common">
@@ -244,8 +243,7 @@
           </table>
         </div>
         <div ng-if="isAuthenticated() && !isEdit">
-          <a class="btn btn-default btn-xs btn-block"
-            ng-click="editClick()">Edit Coordinates</a>
+          <a class="btn btn-default btn-xs btn-block" ng-click="editClick()">Edit Coordinates</a>
         </div>
       </div>
       <my-variant-info variant-info="myVariantInfo" ng-if="myVariantInfo._id"></my-variant-info>
@@ -254,13 +252,7 @@
   <div ng-if="showEvidenceGrid === true">
     <div class="row">
       <div class="col-xs-12 evidence-item-grid">
-        <evidence-grid
-          evidence="evidence"
-          variant="variant"
-          show-gene-col="false"
-          show-variant-col="false"
-          context="'summary'"
-          rounded="false">
+        <evidence-grid evidence="evidence" variant="variant" show-gene-col="false" show-variant-col="false" context="'summary'" rounded="false">
         </evidence-grid>
       </div>
     </div>
@@ -277,32 +269,4 @@
     </div>
   </div>
 
-  <script type="text/ng-template" id="assertionTag.tpl.html">
-    <span uib-tooltip-template="'assertionTagTooltip.tpl.html'">
-      <a ui-sref="events.assertions.summary({ assertionId: assertion.id })" class="assertion-tag" ng-class="{ 'statusAccepted': assertion.status === 'accepted', 'statusSubmitted': assertion.status === 'submitted', 'statusRejected': assertion.status === 'rejected' }">
-        <i class="glyphicon glyphicon-exclamation-sign pending-alert"
-          ng-if="assertion.pending_evidence_count > 0 || assertion.open_change_count > 0"
-          ng-class="{'pending-evidence': assertion.pending_evidence_count > 0,
-            'pending-changes': assertion.open_change_count > 0,
-            'pending-both': assertion.pending_evidence_count > 0 &&
-            assertion.open_change_count > 0}"></i>
-        <span ng-bind-html="assertion.name" class="assertion-name">
-          AssertionName
-        </span>
-      </a>
-    </span>
-  </script>
-
-  <script type="text/ng-template" id="assertionTagTooltip.tpl.html" >
-    <span>
-      <span ng-if="assertion.summary.length > 0">{{assertion.summary}}<br/></span>
-      <span ng-if="assertion.status !== 'accepted'">
-        <strong>Status:</strong> {{ assertion.status }}
-        <br/>
-      </span>
-      <strong>Evidence Items:</strong> <span ng-bind="assertion.evidence_item_count">item count</span><br/>
-      <span ng-if="assertion.pending_evidence_count > 0" style="display:block;">Has {{ assertion.pending_evidence_count }} pending evidence</span>
-      <span ng-if="assertion.open_change_count > 0" style="display:block;">Has {{ assertion.open_change_count }} pending change{{assertion.open_change_count > 1 ? 's' : '' }}</span>
-    </span>
-  </script>
 </div>

--- a/src/components/directives/assertionTag.js
+++ b/src/components/directives/assertionTag.js
@@ -1,0 +1,18 @@
+(function() {
+  'use strict';
+
+  angular.module('civic.common')
+    .directive('assertionTag', assertionTagDirective);
+
+
+  // @ngInject
+  function assertionTagDirective() {
+    return /* @ngInject */ {
+      restrict: 'E',
+      scope: {
+        assertion: '='
+      },
+      templateUrl: 'components/directives/assertionTag.tpl.html'
+    };
+  }
+})();

--- a/src/components/directives/assertionTag.less
+++ b/src/components/directives/assertionTag.less
@@ -1,0 +1,61 @@
+@import 'bower_components/bootstrap/less/mixins.less';
+@import 'bower_components/bootstrap/less/variables.less';
+@import 'src/app/styles/_civic-variables.less';
+@import 'src/app/styles/_mixins.less';
+
+.assertionTag {
+  display: block;
+  .span {
+    text-decoration: none;
+    border-radius: @border-radius-base;
+    background-color: @pageBackground2;
+    border: 1px solid @pageBackground3;
+
+    &:hover, &.active {
+      border-color: @civicPurple;
+      .variant-name {
+        color: @civicPurple;
+      }
+    }
+    .pending-alert {
+      text-shadow:
+      -1px -1px 0 #FFF,
+      1px -1px 0 #FFF,
+      -1px 1px 0 #FFF,
+      1px 1px 0 #FFF !important;
+    }
+    .pending-changes {
+      color: lighten(@civicPurple, 30%) !important;
+    }
+    .pending-evidence {
+      color: #F68F37;
+    }
+    .pending-both {
+      color: @civicRed !important;
+    }
+    &.active {
+      background-color: lighten(@civicPurple, 70%);
+      .variant-name {
+        // font-weight: bold;
+      }
+    }
+
+    &.statusRejected {
+      background-color: #ECA2C0 !important;
+      color: #47161C !important;
+      // border-color: #47161C !important;
+    }
+
+    &.statusAccepted {
+      background-color: #B2D49C !important;
+      color: #144522 !important;
+      // border-color: #144522 !important;
+    }
+
+    &.statusSubmitted {
+      background-color: #F3BC94 !important;
+      color: #4A2B11 !important;
+      // border-color: #4A2B11 !important;
+    }
+  }
+}

--- a/src/components/directives/assertionTag.less
+++ b/src/components/directives/assertionTag.less
@@ -3,10 +3,13 @@
 @import 'src/app/styles/_civic-variables.less';
 @import 'src/app/styles/_mixins.less';
 
+@tabPaddingH: .5em;
+@tabPaddingV: .25em;
+
 .assertionTag {
-  display: block;
-  .span {
+  a {
     text-decoration: none;
+    padding: @tabPaddingV @tabPaddingH;
     border-radius: @border-radius-base;
     background-color: @pageBackground2;
     border: 1px solid @pageBackground3;
@@ -57,5 +60,6 @@
       color: #4A2B11 !important;
       // border-color: #4A2B11 !important;
     }
+
   }
 }

--- a/src/components/directives/assertionTag.tpl.html
+++ b/src/components/directives/assertionTag.tpl.html
@@ -1,0 +1,29 @@
+<div class="assertionTag">
+  <span uib-tooltip-template="'assertionTagTooltip.tpl.html'">
+    <a ui-sref="events.assertions.summary({ assertionId: assertion.id })" class="assertion-tag" ng-class="{ 'statusAccepted': assertion.status === 'accepted', 'statusSubmitted': assertion.status === 'submitted', 'statusRejected': assertion.status === 'rejected' }">
+      <i class="glyphicon glyphicon-exclamation-sign pending-alert"
+        ng-if="assertion.pending_evidence_count > 0 || assertion.open_change_count > 0"
+        ng-class="{'pending-evidence': assertion.pending_evidence_count > 0,
+        'pending-changes': assertion.open_change_count > 0,
+        'pending-both': assertion.pending_evidence_count > 0 &&
+        assertion.open_change_count > 0}"></i>
+      <span ng-bind-html="assertion.name" class="assertion-name">
+        AssertionName
+      </span>
+    </a>
+  </span>
+</div>
+
+<script type="text/ng-template" id="assertionTagTooltip.tpl.html">
+  <span>
+    <span ng-if="assertion.summary.length > 0">{{assertion.summary}}<br/></span>
+  <span ng-if="assertion.status !== 'accepted'">
+      <strong>Status:</strong> {{ assertion.status }}
+      <br/>
+    </span>
+  <strong>Evidence Items:</strong> <span ng-bind="assertion.evidence_item_count">item count</span>
+  <br/>
+  <span ng-if="assertion.pending_evidence_count > 0" style="display:block;">Has {{ assertion.pending_evidence_count }} pending evidence</span>
+  <span ng-if="assertion.open_change_count > 0" style="display:block;">Has {{ assertion.open_change_count }} pending change{{assertion.open_change_count > 1 ? 's' : '' }}</span>
+  </span>
+</script>

--- a/src/components/directives/evidenceSelectorItem.js
+++ b/src/components/directives/evidenceSelectorItem.js
@@ -27,11 +27,10 @@
     var variant_id = _.isUndefined(ctrl.item.variant_id) ? ctrl.item.state_params.variant.id : ctrl.item.variant_id;
 
     if($scope.ctrl.item.phenotypes.length > 0) {
-      var hpoUrl = ConfigService.hpoUrl;
       $scope.ctrl.item.phenotypesStr = _.chain($scope.ctrl.item.phenotypes)
         .sortBy('hpo_class')
         .map(function(item) {
-          return '<a href="' + hpoUrl + item.hpo_id + '" target="_blank">' + item.hpo_class + '</a>';
+          return '<a href="' + item.url +  '" target="_blank">' + item.hpo_class + '</a>';
         })
         .value()
         .join(', ');

--- a/src/components/directives/evidenceSelectorItem.js
+++ b/src/components/directives/evidenceSelectorItem.js
@@ -17,7 +17,7 @@
   }
 
   // @ngInject
-  function evidenceSelectorItemController($scope, $state, _, Genes, Variants) {
+  function evidenceSelectorItemController($scope, $state, _, Genes, Variants, ConfigService) {
     var ctrl = $scope.ctrl = {};
     ctrl.item = $scope.item;
     ctrl.removeItem = $scope.removeFn;
@@ -27,7 +27,14 @@
     var variant_id = _.isUndefined(ctrl.item.variant_id) ? ctrl.item.state_params.variant.id : ctrl.item.variant_id;
 
     if($scope.ctrl.item.phenotypes.length > 0) {
-      $scope.ctrl.item.phenotypesStr = _.chain($scope.ctrl.item.phenotypes).map('hpo_class').sort().value().join(', ');
+      var hpoUrl = ConfigService.hpoUrl;
+      $scope.ctrl.item.phenotypesStr = _.chain($scope.ctrl.item.phenotypes)
+        .sortBy('hpo_class')
+        .map(function(item) {
+          return '<a href="' + hpoUrl + item.hpo_id + '" target="_blank">' + item.hpo_class + '</a>';
+        })
+        .value()
+        .join(', ');
     } else {
       $scope.ctrl.item.phenotypesStr = '--';
     }

--- a/src/components/directives/evidenceSelectorItem.js
+++ b/src/components/directives/evidenceSelectorItem.js
@@ -26,6 +26,12 @@
     var gene_id = _.isUndefined(ctrl.item.gene_id) ? ctrl.item.state_params.gene.id : ctrl.item.gene_id;
     var variant_id = _.isUndefined(ctrl.item.variant_id) ? ctrl.item.state_params.variant.id : ctrl.item.variant_id;
 
+    if($scope.ctrl.item.phenotypes.length > 0) {
+      $scope.ctrl.item.phenotypesStr = _.chain($scope.ctrl.item.phenotypes).map('hpo_class').sort().value().join(', ');
+    } else {
+      $scope.ctrl.item.phenotypesStr = '--';
+    }
+
     Genes.get(gene_id).then(function(gene) {
       ctrl.item.gene = gene;
     });

--- a/src/components/directives/evidenceSelectorItem.less
+++ b/src/components/directives/evidenceSelectorItem.less
@@ -34,7 +34,6 @@
       cursor: help;
     }
   }
-
   .levelBadge {
     display: inline-block;
     padding: 3px 10px;

--- a/src/components/directives/evidenceSelectorItem.tpl.html
+++ b/src/components/directives/evidenceSelectorItem.tpl.html
@@ -68,10 +68,15 @@
             {{ ctrl.item.drugsStr }}<span ng-if="ctrl.item.drug_interaction_type">&nbsp;({{ ctrl.item.drug_interaction_type }})</span>
           </td>
         </tr>
-        <!-- <tr ng-show="ctrl.item.drug_interaction_type"> -->
-        <!-- <td class="name">Drug Interaction:</td> -->
-        <!-- <td class="value">{{ ctrl.item.drug_interaction_type }}</td> -->
-        <!-- </tr> -->
+        <tr ng-if="ctrl.item.assertions.length > 0">
+          <td class="name" style="padding-top: 5px;padding-bottom: 0;">
+            Supports Assertions:
+          </td>
+          <td class="value assertions">
+            <assertion-tag ng-repeat="assertion in ctrl.item.assertions | orderBy:'id'" ng-show="assertion.status !== 'rejected' || showAll === true" assertion="assertion">
+            </assertion-tag>
+          </td>
+        </tr>
       </table>
     </div>
     <div class="col-xs-12 col-md-6 details">

--- a/src/components/directives/evidenceSelectorItem.tpl.html
+++ b/src/components/directives/evidenceSelectorItem.tpl.html
@@ -62,6 +62,16 @@
             </span>
           </td>
         </tr>
+        <tr ng-if="ctrl.item.evidence_type == 'Predictive'">
+          <td class="name">Drug:</td>
+          <td class="value">
+            {{ ctrl.item.drugsStr }}<span ng-if="ctrl.item.drug_interaction_type">&nbsp;({{ ctrl.item.drug_interaction_type }})</span>
+          </td>
+        </tr>
+        <!-- <tr ng-show="ctrl.item.drug_interaction_type"> -->
+        <!-- <td class="name">Drug Interaction:</td> -->
+        <!-- <td class="value">{{ ctrl.item.drug_interaction_type }}</td> -->
+        <!-- </tr> -->
       </table>
     </div>
     <div class="col-xs-12 col-md-6 details">
@@ -79,13 +89,9 @@
             </a>
           </td>
         </tr>
-        <tr ng-if="ctrl.item.evidence_type == 'Predictive'">
-          <td class="name">Drug:</td>
-          <td class="value">{{ ctrl.item.drugsStr }}</td>
-        </tr>
-        <tr ng-show="ctrl.item.drug_interaction_type">
-          <td class="name">Drug Interaction:</td>
-          <td class="value">{{ ctrl.item.drug_interaction_type }}</td>
+        <tr>
+          <td class="name">Associated Phenotype{{ ctrl.item.phenotypes.length > 1 ? 's' : '' }}:</td>
+          <td class="value">{{ ctrl.item.phenotypesStr }}</td>
         </tr>
         <tr>
           <td class="name">Citation:</td>

--- a/src/components/directives/evidenceSelectorItem.tpl.html
+++ b/src/components/directives/evidenceSelectorItem.tpl.html
@@ -91,7 +91,7 @@
         </tr>
         <tr>
           <td class="name">Associated Phenotype{{ ctrl.item.phenotypes.length > 1 ? 's' : '' }}:</td>
-          <td class="value">{{ ctrl.item.phenotypesStr }}</td>
+          <td class="value" ng-bind-html="ctrl.item.phenotypesStr"></td>
         </tr>
         <tr>
           <td class="name">Citation:</td>

--- a/src/components/directives/evidenceSelectorItem.tpl.html
+++ b/src/components/directives/evidenceSelectorItem.tpl.html
@@ -79,7 +79,7 @@
             </a>
           </td>
         </tr>
-        <tr>
+        <tr ng-if="ctrl.item.evidence_type == 'Predictive'">
           <td class="name">Drug:</td>
           <td class="value">{{ ctrl.item.drugsStr }}</td>
         </tr>

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -57,7 +57,6 @@
   angular.module('civic.services')
     .constant('ConfigService', {
       serverUrl: 'http://127.0.0.1:3000/',
-      hpoUrl: 'http://compbio.charite.de/hpoweb/showterm?id=',
       optionMethods: {
         make_obj: make_obj,
         make_options: make_options,

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -57,6 +57,7 @@
   angular.module('civic.services')
     .constant('ConfigService', {
       serverUrl: 'http://127.0.0.1:3000/',
+      hpoUrl: 'http://compbio.charite.de/hpoweb/showterm?id=',
       optionMethods: {
         make_obj: make_obj,
         make_options: make_options,


### PR DESCRIPTION
Evidence cards on assertion summary view are sorted by Evidence Level by default, and user can also alternatively select sorting by ID or Rating as well.