### PR TITLE
fixes several attributes with 'is_empty' options

### DIFF
--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -1167,7 +1167,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -3071,7 +3076,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -3623,7 +3633,7 @@
                   required: true
                 }
               }
-            ],
+            ]
           }
         }
       }

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -1125,6 +1125,7 @@
                 data: {
                   defaultValue: null
                 },
+                hideExpression: 'model.name =="is_empty" || model.name == "is_not_empty"',
                 templateOptions: {
                   label: '',
                   required: true,
@@ -2449,8 +2450,11 @@
                   options: [
                     {value: 'is_equal_to', name: 'is'},
                     {value: 'is_not_equal_to', name: 'is not'},
-                    {value: 'is_empty', name: 'is empty'}
-                  ]
+                    {value: 'is_empty', name: 'is empty'},
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(value === 'is_empty') { scope.model.parameters[0] = null; }
+                  }
                 }
               },
               {
@@ -2458,12 +2462,13 @@
                 type: 'queryBuilderSelect',
                 className: 'inline-field',
                 data: {
-                  defaultValue: '1'
+                  defaultValue: null
                 },
+                hideExpression: 'model.name =="is_empty" || model.name == "is_not_empty"',
                 templateOptions: {
                   label: '',
                   required: true,
-                  options: ConfigService.valid_chromosomes
+                  options: [{ value: null, name: 'Please choose a chromosome'}].concat(ConfigService.valid_chromosomes)
                 }
               }
             ],
@@ -2609,7 +2614,7 @@
                   options: [
                     {value: 'is_equal_to', name: 'is'},
                     {value: 'is_not_equal_to', name: 'is not'},
-                    {value: 'is_empty', name: 'is empty'}
+                    {value: 'is_empty', name: 'is empty'},
                   ]
                 }
               },
@@ -2620,6 +2625,7 @@
                 data: {
                   defaultValue: '1'
                 },
+                hideExpression: 'model.name =="is_empty" || model.name == "is_not_empty"',
                 templateOptions: {
                   label: '',
                   required: true,

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -205,7 +205,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -235,7 +240,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -248,7 +258,8 @@
                   required: true,
                   typeahead: 'item.name as item.name for item in to.data.typeaheadSearch($viewValue)',
                   editable: true,
-                  templateUrl: 'components/forms/fieldTypes/diseaseTypeahead.tpl.html',                                 data: {
+                  templateUrl: 'components/forms/fieldTypes/diseaseTypeahead.tpl.html',
+                  data: {
                     typeaheadSearch: function(val) {
                       return Diseases.beginsWith(val)
                         .then(function(response) {
@@ -274,7 +285,12 @@
                     {value: 'is', name: 'is'},
                     {value: 'is_not', name: 'is not'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -870,7 +886,7 @@
                     {value: 'contains', name: 'contains'},
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
-		    {value: 'is_empty', name: 'is empty'}
+                    {value: 'is_empty', name: 'is empty'}
                   ]
                 }
               },
@@ -878,7 +894,7 @@
                 key: 'parameters[0]',
                 type: 'input',
                 className: 'inline-field',
-		hideExpression: 'model.name === "is_empty"',
+                hideExpression: 'model.name === "is_empty"',
                 templateOptions: {
                   label: '',
                   required: true
@@ -1758,7 +1774,7 @@
                     {value: 'contains', name: 'contains'},
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
-		    {value: 'is_empty', name: 'is empty'}
+                    {value: 'is_empty', name: 'is empty'}
                   ]
                 }
               },
@@ -1766,7 +1782,7 @@
                 key: 'parameters[0]',
                 type: 'input',
                 className: 'inline-field',
-		hideExpression: 'model.name === "is_empty"',
+                hideExpression: 'model.name === "is_empty"',
                 templateOptions: {
                   label: '',
                   required: true
@@ -2266,7 +2282,7 @@
                     {value: 'contains', name: 'contains'},
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
-		    {value: 'is_empty', name: 'is empty'}
+                    {value: 'is_empty', name: 'is empty'}
                   ]
                 }
               },
@@ -2274,7 +2290,7 @@
                 key: 'parameters[0]',
                 type: 'input',
                 className: 'inline-field',
-		hideExpression: 'model.name === "is_empty"',
+                hideExpression: 'model.name === "is_empty"',
                 templateOptions: {
                   label: '',
                   required: true
@@ -2453,7 +2469,9 @@
                     {value: 'is_empty', name: 'is empty'},
                   ],
                   onChange: function(value, options, scope) {
-                    if(value === 'is_empty') { scope.model.parameters[0] = null; }
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
                   }
                 }
               },
@@ -2464,7 +2482,7 @@
                 data: {
                   defaultValue: null
                 },
-                hideExpression: 'model.name =="is_empty" || model.name == "is_not_empty"',
+                hideExpression: 'model.name == "is_empty"',
                 templateOptions: {
                   label: '',
                   required: true,
@@ -2607,6 +2625,11 @@
                 className: 'inline-field inline-field-md',
                 data: {
                   defaultValue: 'is_equal_to'
+                },
+                onChange: function(value, options, scope) {
+                  if(scope.model.name.match(/empty/)) {
+                    _.pullAt(scope.model.parameters, 0);
+                  }
                 },
                 templateOptions: {
                   label: '',
@@ -3339,7 +3362,7 @@
                   required: true
                 }
               }
-           ],
+            ],
             evidence_item_count: [
               {
                 template: 'with status',

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -1982,7 +1982,13 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
+
                 }
               },
               {
@@ -2161,7 +2167,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -2191,7 +2202,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -2220,7 +2236,12 @@
                     {value: 'contains', name: 'contains'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -2283,7 +2304,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {
@@ -2408,7 +2434,12 @@
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
                     {value: 'is_empty', name: 'is empty'}
-                  ]
+                  ],
+                  onChange: function(value, options, scope) {
+                    if(scope.model.name.match(/empty/)) {
+                      _.pullAt(scope.model.parameters, 0);
+                    }
+                  }
                 }
               },
               {

--- a/src/app/views/search/forms/queryBuilder.type.tpl.html
+++ b/src/app/views/search/forms/queryBuilder.type.tpl.html
@@ -38,4 +38,9 @@
       </div>
     </div>
   </div>
+  <!-- <div class="row" > -->
+  <!-- <div class="col-xs-12" > -->
+  <!-- <pre ng-bind="model|json" -->
+  <!-- </div> -->
+  <!-- </div> -->
 </div>


### PR DESCRIPTION
Several attributes would send parameter values to the server even when set to is_empty: when an is_equal_to value was set and then switched to is_empty, or initially set with a default value. Now attributes with is_empty have onChange watchers that clear the parameter arrays when is_empty is chosen.