### PR TITLE
browse grid now includes sort_priority attribute in request object

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -894,8 +894,12 @@
       }
 
       if (sorting.length > 0) {
-        _.each(sorting, function(sort) {
+        request.sort_priority = '';
+        var length = sorting.length;
+        _.each(sorting, function(sort, index) {
           request['sorting[' + sort.field + ']'] = sort.direction;
+          request.sort_priority += sort.field;
+          if (index+1 < length) { request.sort_priority += ',';}
         });
       }
       return Datatables.query(request);

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -40,15 +40,25 @@
 
     ctrl.filters = [];
 
-    if(ctrl.mode !== 'evidence_items' && ctrl.mode !== 'assertions') {
+    if(ctrl.mode == 'evidence_items') {
+      ctrl.sorting = [
+        {
+          field: 'evidence_level',
+          direction: 'asc',
+        },
+        {
+          field: 'rating',
+          direction: 'desc',
+        },
+        {
+          field: 'evidence_type',
+          direction: 'asc',
+        },
+      ];
+    } else {
       ctrl.sorting = [{
         field: 'evidence_item_count',
         direction: 'desc'
-      }];
-    } else {
-      ctrl.sorting = [{
-        field: 'id',
-        direction: 'asc'
       }];
     }
 


### PR DESCRIPTION
The angularjs $resource in DatatablesService returns a GET query function that sorts parameters alphabetically before constructing its URL, which plays havoc with any attempt to use the URL param order to ensure sort priority. Instead, we now include a sort_priority attribute with a comma-delimited string of column names to be used for constructing the sort query on the server side.