### PR TITLE
Enable advanced search on organization name for evidence items and assertions

### DIFF
--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -1007,6 +1007,7 @@
                   label: '',
                   required: true,
                   options:[
+                    { value: null, name: 'Please choose an Organization' },
                     { value: 'BCCA (POGS)', name: 'BCCA (POGS)' },
                     { value: 'The Charité Comprehensive Cancer Center', name: 'The Charité Comprehensive Cancer Center' },
                     { value: 'ClinGen', name: 'ClinGen' },
@@ -1897,6 +1898,7 @@
                   label: '',
                   required: true,
                   options:[
+                    { value: null, name: 'Please choose an Organization' },
                     { value: 'BCCA (POGS)', name: 'BCCA (POGS)' },
                     { value: 'The Charité Comprehensive Cancer Center', name: 'The Charité Comprehensive Cancer Center' },
                     { value: 'ClinGen', name: 'ClinGen' },

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -57,6 +57,7 @@
                   { value: 'status', name: 'Status' },
                   { value: 'submitter', name: 'Submitter Display Name' },
                   { value: 'submitter_id', name: 'Submitter ID' },
+                  { value: 'submitter_organization', name: 'Submitter Organization' },
                   { value: 'suggested_changes_count', name: 'Suggested Revisions' },
                   { value: 'variant_alias', name: 'Variant Alias' },
                   { value: 'variant_name', name: 'Variant Name' },
@@ -977,7 +978,45 @@
                   required: true
                 }
               }
-            ]
+            ],
+            submitter_organization: [
+              {
+                key: 'name',
+                type: 'queryBuilderSelect',
+                className: 'inline-field inline-field-md',
+                data: {
+                  defaultValue: 'is_equal_to'
+                },
+                templateOptions: {
+                  label: '',
+                  required: true,
+                  options: [
+                    {value: 'is_equal_to', name: 'is'},
+                    {value: 'is_not_equal_to', name: 'is not'}
+                  ]
+                }
+              },
+              {
+                key: 'parameters[0]',
+                type: 'queryBuilderSelect',
+                className: 'inline-field',
+                data: {
+                  defaultValue: null
+                },
+                templateOptions: {
+                  label: '',
+                  required: true,
+                  options:[
+                    { value: 'BCCA (POGS)', name: 'BCCA (POGS)' },
+                    { value: 'The Charité Comprehensive Cancer Center', name: 'The Charité Comprehensive Cancer Center' },
+                    { value: 'ClinGen', name: 'ClinGen' },
+                    { value: 'Illumina', name: 'Illumina' },
+                    { value: 'The McDonnell Genome Institute', name: 'The McDonnell Genome Institute'},
+                    { value: 'University Health Network (Toronto)', name: 'University Health Network (Toronto)' },
+                  ]
+                }
+              }
+            ],
           }
         }
       }
@@ -1017,6 +1056,7 @@
                   { value: 'status', name: 'Status' },
                   { value: 'submitter', name: 'Submitter Display Name' },
                   { value: 'submitter_id', name: 'Submitter ID' },
+                  { value: 'submitter_organization', name: 'Submitter Organization' },
                   { value: 'suggested_changes_count', name: 'Suggested Revisions' },
                   { value: 'variant_alias', name: 'Variant Alias' },
                   { value: 'variant_name', name: 'Variant Name' },
@@ -1828,7 +1868,45 @@
                   required: true
                 }
               }
-            ]
+            ],
+            submitter_organization: [
+              {
+                key: 'name',
+                type: 'queryBuilderSelect',
+                className: 'inline-field inline-field-md',
+                data: {
+                  defaultValue: 'is_equal_to'
+                },
+                templateOptions: {
+                  label: '',
+                  required: true,
+                  options: [
+                    {value: 'is_equal_to', name: 'is'},
+                    {value: 'is_not_equal_to', name: 'is not'}
+                  ]
+                }
+              },
+              {
+                key: 'parameters[0]',
+                type: 'queryBuilderSelect',
+                className: 'inline-field',
+                data: {
+                  defaultValue: null
+                },
+                templateOptions: {
+                  label: '',
+                  required: true,
+                  options:[
+                    { value: 'BCCA (POGS)', name: 'BCCA (POGS)' },
+                    { value: 'The Charité Comprehensive Cancer Center', name: 'The Charité Comprehensive Cancer Center' },
+                    { value: 'ClinGen', name: 'ClinGen' },
+                    { value: 'Illumina', name: 'Illumina' },
+                    { value: 'The McDonnell Genome Institute', name: 'The McDonnell Genome Institute'},
+                    { value: 'University Health Network (Toronto)', name: 'University Health Network (Toronto)' },
+                  ]
+                }
+              }
+            ],
           }
         }
       }


### PR DESCRIPTION
The list of organizations is currently hard-coded. This should be changed to get the list of organizations from the server at some point in the near future as more organizations are added.

Closes #947 