### PR TITLE
Add assertion summaries links to TSV downloads

### DIFF
--- a/src/app/pages/ReleasesController.js
+++ b/src/app/pages/ReleasesController.js
@@ -10,9 +10,6 @@
     // TODO move releases init to ui-router state resolve
     Releases.initBase().then(function(releases){
       vm.releases = _.map(releases[0], function(release) {
-        release.fileNames = _.map(release.files, function(filename) {
-          return _.last(filename.split('/'));
-        });
         release.fileUrls = _.map(release.files, function(filename) {
           return filename;
         });

--- a/src/app/pages/releases.tpl.html
+++ b/src/app/pages/releases.tpl.html
@@ -42,6 +42,9 @@
           <th>
             Evidence Summaries
           </th>
+          <th>
+            Assertion Summaries
+          </th>
         </tr>
         <tr ng-repeat="release in vm.releases">
           <td class="date" ng-bind="release.note | capitalize">
@@ -70,6 +73,14 @@
             <a class="btn btn-xs btn-default" ng-href="{{release.fileUrls[2]}}" target="_self">
               <span class="glyphicon glyphicon-download-alt"></span>
               ClinicalEvidenceSummaries.tsv
+            </a>
+          </td>
+          <td class="link">
+            <a class="btn btn-xs btn-default"
+              ng-href="{{release.fileUrls[4]}}"
+              ng-if="release.fileUrls[4] != null" target="_self">
+              <span class="glyphicon glyphicon-download-alt"></span>
+              AssertionSummaries.tsv
             </a>
           </td>
         </tr>


### PR DESCRIPTION
The server will return null for tsvs that don't exists so this PR also contains changes to handle this. That way the client won't display a button for tsvs that don't actually exist.

Closes https://github.com/griffithlab/civic-client/issues/897