### PR TITLE
variant menu now shows filters in a button-activated popover window, contains additional checkbox filters

### DIFF
--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -27,10 +27,7 @@
     $scope.hasHiddenVariants = false;
     $scope.variants = Genes.data.variants;
 
-    $scope.showAccepted = true;
-    $scope.showSubmitted = false;
-    $scope.showNoAccepted = false;
-    $scope.showOnlySubmitted = false;
+    $scope.options_filter = 'accepted';
 
     // functions used in ng-show directive on variant buttons
     $scope.hasValidEvidenceItems = function(variant) { // has accepted and/or submitted items

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -27,7 +27,6 @@
     $scope.hasHiddenVariants = false;
     $scope.variants = Genes.data.variants;
 
-    $scope.options_filter = 'accepted';
 
     // functions used in ng-show directive on variant buttons
     $scope.hasValidEvidenceItems = function(variant) { // has accepted and/or submitted items
@@ -67,6 +66,17 @@
       submitted: 0, // variants with submitted evidence
       rejected: 0,
       orphaned: 0 // variants with rejected evidence
+    };
+
+    $scope.options_filter = 'accepted';
+    $scope.query = '';
+    $scope.variantFilterFn = function(variant) {
+      var show = ( ( $scope.options_filter === 'accepted' && $scope.hasAcceptedItems(variant) )
+                   || ( $scope.options_filter === 'accepted_submitted' && ($scope.hasAcceptedItems(variant) || $scope.hasSubmittedItems(variant)) )
+                   || ( $scope.options_filter === 'submitted' && $scope.hasSubmittedItems(variant) )
+                   || ( variant.id === $scope.stateParams.variantId )
+                   || ( $scope.options_filter === 'all' ) );
+      return show;
     };
 
     $scope.$watchCollection(

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -20,6 +20,10 @@
     $scope.hasHiddenVariants = false;
     $scope.variants = Genes.data.variants;
 
+    $scope.showAccepted = true;
+    $scope.showSubmitted = false;
+    $scope.showRejected = false;
+
     $scope.security = {
       isAuthenticated: Security.isAuthenticated(),
       isEditor: Security.isEditor(),
@@ -28,14 +32,20 @@
 
     $scope.$state = $state;
 
+    // use !hasValidEvidenceItems to get only rejected
     $scope.hasValidEvidenceItems = function(variant) {
       var statuses = variant.evidence_item_statuses;
       return (statuses.accepted_count + statuses.submitted_count) > 0;
     };
 
-    $scope.hasAcceptedEvidenceItems = function(variant) {
+    $scope.hasOnlyAcceptedItems = function(variant) {
       var statuses = variant.evidence_item_statuses;
       return (statuses.accepted_count) > 0;
+    };
+
+    $scope.hasOnlySubmittedItems = function(variant) {
+      var statuses = variant.evidence_item_statuses;
+      return (statuses.accepted_count === 0 && statuses.submitted_count > 0);
     };
 
     var addVarGroupUrlBase = $scope.addVarGroupUrl = 'add/variantGroup';
@@ -49,9 +59,11 @@
     $scope.$watchCollection(
       function() { return Genes.data.variantsStatus.variants; },
       function(variants){
-        $scope.hasHiddenVariants = !_.every(variants, function(variant) {
-          return $scope.hasValidEvidenceItems(variant);
+        // _.reduce(collection, [iteratee=_.identity], [accumulator])
+        $scope.variantsWithOnlySubmitted = _.reduce(variants, function(v) {
+
         });
+        $scope.variantsWithOnlyRejected = 0;
         $scope.variants = variants;
       });
 

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -68,7 +68,8 @@
     $scope.evidence_category_counts = {
       accepted: 0, // variants with accepted evidence
       submitted: 0, // variants with submitted evidence
-      rejected: 0 // variants with rejected evidence
+      rejected: 0,
+      orphaned: 0 // variants with rejected evidence
     };
 
     $scope.$watchCollection(
@@ -79,6 +80,7 @@
           if (counts.accepted_count > 0) { $scope.evidence_category_counts.accepted++;}
           if (counts.submitted_count > 0) { $scope.evidence_category_counts.submitted++;}
           if (counts.rejected_count > 0) { $scope.evidence_category_counts.rejected++;}
+          if (counts.accepted_count === 0 && counts.submitted_count === 0 && counts.rejected_count === 0) { $scope.evidence_category_counts.orphaned++;}
         });
         $scope.variants = variants;
       });

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -71,12 +71,11 @@
     $scope.options_filter = 'accepted';
     $scope.query = '';
     $scope.variantFilterFn = function(variant) {
-      var show = ( ( $scope.options_filter === 'accepted' && $scope.hasAcceptedItems(variant) )
-                   || ( $scope.options_filter === 'accepted_submitted' && ($scope.hasAcceptedItems(variant) || $scope.hasSubmittedItems(variant)) )
-                   || ( $scope.options_filter === 'submitted' && $scope.hasSubmittedItems(variant) )
-                   || ( variant.id === $scope.stateParams.variantId )
-                   || ( $scope.options_filter === 'all' ) );
-      return show;
+      return  ( $scope.options_filter === 'accepted' && $scope.hasAcceptedItems(variant) )
+        || ( $scope.options_filter === 'accepted_submitted' && ($scope.hasAcceptedItems(variant) || $scope.hasSubmittedItems(variant)) )
+        || ( $scope.options_filter === 'submitted' && $scope.hasSubmittedItems(variant) )
+        || ( variant.id === $scope.stateParams.variantId )
+        || ( $scope.options_filter === 'all' ) ;
     };
 
     $scope.$watchCollection(

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -33,6 +33,11 @@
       return (statuses.accepted_count + statuses.submitted_count) > 0;
     };
 
+    $scope.hasAcceptedEvidenceItems = function(variant) {
+      var statuses = variant.evidence_item_statuses;
+      return (statuses.accepted_count) > 0;
+    };
+
     var addVarGroupUrlBase = $scope.addVarGroupUrl = 'add/variantGroup';
 
     $scope.$watchCollection('stateParams', function(stateParams){

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -29,7 +29,7 @@
 
     $scope.showAccepted = true;
     $scope.showSubmitted = false;
-    $scope.showRejected = false;
+    $scope.showNoAccepted = false;
     $scope.showOnlySubmitted = false;
 
     // functions used in ng-show directive on variant buttons
@@ -48,8 +48,13 @@
       return (statuses.accepted_count === 0 && statuses.submitted_count > 0);
     };
 
+    $scope.hasNoAcceptedItems = function(variant) {
+      return !$scope.hasAcceptedItems(variant);
+    };
+
     $scope.hasOnlyRejectedItems = function(variant) {
-      return !$scope.hasValidEvidenceItems(variant);
+      var statuses = variant.evidence_item_statuses;
+      return statuses.rejected_count > 0 && (statuses.accepted_count === 0 && statuses.submitted_count === 0);
     };
 
     var addVarGroupUrlBase = $scope.addVarGroupUrl = 'add/variantGroup';

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -15,6 +15,13 @@
 
   //@ngInject
   function VariantMenuController($scope, $state, $stateParams, Genes, Security, _) {
+    $scope.security = {
+      isAuthenticated: Security.isAuthenticated(),
+      isEditor: Security.isEditor(),
+      isAdmin: Security.isAdmin()
+    };
+
+    $scope.$state = $state;
     $scope.gene = Genes.data.item;
     $scope.stateParams = $stateParams;
     $scope.hasHiddenVariants = false;
@@ -23,22 +30,15 @@
     $scope.showAccepted = true;
     $scope.showSubmitted = false;
     $scope.showRejected = false;
+    $scope.showOnlySubmitted = false;
 
-    $scope.security = {
-      isAuthenticated: Security.isAuthenticated(),
-      isEditor: Security.isEditor(),
-      isAdmin: Security.isAdmin()
-    };
-
-    $scope.$state = $state;
-
-    // use !hasValidEvidenceItems to get only rejected
+    // functions used in ng-show directive on variant buttons
     $scope.hasValidEvidenceItems = function(variant) {
       var statuses = variant.evidence_item_statuses;
       return (statuses.accepted_count + statuses.submitted_count) > 0;
     };
 
-    $scope.hasOnlyAcceptedItems = function(variant) {
+    $scope.hasAcceptedItems = function(variant) {
       var statuses = variant.evidence_item_statuses;
       return (statuses.accepted_count) > 0;
     };
@@ -46,6 +46,10 @@
     $scope.hasOnlySubmittedItems = function(variant) {
       var statuses = variant.evidence_item_statuses;
       return (statuses.accepted_count === 0 && statuses.submitted_count > 0);
+    };
+
+    $scope.hasOnlyRejectedItems = function(variant) {
+      return !$scope.hasValidEvidenceItems(variant);
     };
 
     var addVarGroupUrlBase = $scope.addVarGroupUrl = 'add/variantGroup';

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -33,7 +33,7 @@
     $scope.showOnlySubmitted = false;
 
     // functions used in ng-show directive on variant buttons
-    $scope.hasValidEvidenceItems = function(variant) {
+    $scope.hasValidEvidenceItems = function(variant) { // has accepted and/or submitted items
       var statuses = variant.evidence_item_statuses;
       return (statuses.accepted_count + statuses.submitted_count) > 0;
     };
@@ -43,18 +43,19 @@
       return (statuses.accepted_count) > 0;
     };
 
-    $scope.hasOnlySubmittedItems = function(variant) {
+    $scope.hasSubmittedItems = function(variant) {
       var statuses = variant.evidence_item_statuses;
-      return (statuses.accepted_count === 0 && statuses.submitted_count > 0);
+      return (statuses.submitted_count) > 0;
     };
 
-    $scope.hasNoAcceptedItems = function(variant) {
-      return !$scope.hasAcceptedItems(variant);
+    $scope.hasRejectedItems = function(variant) {
+      var statuses = variant.evidence_item_statuses;
+      return (statuses.submitted_count) > 0;
     };
 
-    $scope.hasOnlyRejectedItems = function(variant) {
+    $scope.hasNoItems = function(variant) { // is orphan
       var statuses = variant.evidence_item_statuses;
-      return statuses.rejected_count > 0 && (statuses.accepted_count === 0 && statuses.submitted_count === 0);
+      return statuses.accepted_count === 0 && statuses.submitted_count === 0 && statuses.rejected_count === 0;
     };
 
     var addVarGroupUrlBase = $scope.addVarGroupUrl = 'add/variantGroup';
@@ -64,15 +65,21 @@
         $scope.addVarGroupUrl = addVarGroupUrlBase + '?geneId=' + stateParams.geneId;
       }
     });
+    $scope.evidence_category_counts = {
+      accepted: 0, // variants with accepted evidence
+      submitted: 0, // variants with submitted evidence
+      rejected: 0 // variants with rejected evidence
+    };
 
     $scope.$watchCollection(
       function() { return Genes.data.variantsStatus.variants; },
       function(variants){
-        // _.reduce(collection, [iteratee=_.identity], [accumulator])
-        $scope.variantsWithOnlySubmitted = _.reduce(variants, function(v) {
-
+        _.forEach(variants, function(variant) {
+          var counts = variant.evidence_item_statuses;
+          if (counts.accepted_count > 0) { $scope.evidence_category_counts.accepted++;}
+          if (counts.submitted_count > 0) { $scope.evidence_category_counts.submitted++;}
+          if (counts.rejected_count > 0) { $scope.evidence_category_counts.rejected++;}
         });
-        $scope.variantsWithOnlyRejected = 0;
         $scope.variants = variants;
       });
 

--- a/src/app/views/events/genes/summary/variantMenu.less
+++ b/src/app/views/events/genes/summary/variantMenu.less
@@ -16,19 +16,6 @@
     margin-top: 1.5 * @contentPadding;
   }
 
-  .checkbox-field {
-    text-align: right;
-    div { display: inline-block; }
-    label {
-      font-size: small;
-      font-weight: normal !important;
-      color: #666;
-    }
-    label, input {
-      cursor: pointer;
-    }
-  }
-
   .filter {
     height: 22px;
     padding: 2px 5px;
@@ -142,4 +129,9 @@
       line-height: 1em;
     }
   }
+
+  .filters-content {
+    min-width: 200px;
+  }
+
 }

--- a/src/app/views/events/genes/summary/variantMenu.less
+++ b/src/app/views/events/genes/summary/variantMenu.less
@@ -16,7 +16,7 @@
     margin-top: 1.5 * @contentPadding;
   }
 
-  .show-all {
+  .checkbox-field {
     text-align: right;
     div { display: inline-block; }
     label {

--- a/src/app/views/events/genes/summary/variantMenu.less
+++ b/src/app/views/events/genes/summary/variantMenu.less
@@ -33,7 +33,12 @@
     padding: 0;
     margin-left: @contentPadding/2;
   }
-
+  .radio {
+    .count {
+      color: #AAA;
+      font-style: oblique;
+    }
+  }
   .sub-title {
     font-weight: bold;
     text-decoration: underline;

--- a/src/app/views/events/genes/summary/variantMenu.less
+++ b/src/app/views/events/genes/summary/variantMenu.less
@@ -131,7 +131,7 @@
   }
 
   .filters-content {
-    min-width: 200px;
+    min-width: 400px;
   }
 
 }

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -91,25 +91,25 @@
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="accepted">
-      <span uib-tooltip="Includes only variants with accepted evidence">Show variants with editor reviewed evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
+      <span uib-tooltip="Includes variants that have at least one editor-reviewed evidence item">Show variants with accepted evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="accepted_submitted">
-      <span uib-tooltip="Includes variants with accepted and/or pending evidence">Show variants with editor reviewed evidence and/or evidence pending review <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
+      <span uib-tooltip="Includes variants that have at least one editor-reviewed and/or pending evidence item">Show variants with accepted and/or submitted evidence <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="submitted">
-      <span uib-tooltip="Includes variants with pending evidence">Show variants with evidence pending review <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
+      <span uib-tooltip="Includes variants that have at least one item of evidence pending editor review">Show variants with submitted evidence <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="all">
-      <span uib-tooltip="Includes variants with accepted, pending, rejected evidence, or no evidence at all (orphans)">Show all variants <span class="count" >({{$parent.variants.length}})</span></span>
+      <span uib-tooltip="Includes all variants">Show all: variants with accepted, submitted, rejected, and/or no evidence (orphans) <span class="count" >({{$parent.variants.length}})</span></span>
     </label>
   </div>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -33,9 +33,9 @@
       <ul class="variants">
         <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results"
           ng-show="(showAccepted && hasAcceptedItems(variant))
-          || (showSubmitted && hasOnlySubmittedItems(variant))
-          || (showNoAccepted && hasNoAcceptedItems(variant))
-          || (showOnlyRejected && hasOnlyRejectedItems(variant))
+          || (showSubmitted && hasSubmittedItems(variant))
+          || (showRejected && hasRejectedItems(variant))
+          || (showOrphans && hasNoItems(variant))
           || variant.id == stateParams.variantId">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -9,12 +9,12 @@
       </div>
       <div class="col-xs-2" style="text-align: right;">
         <a uib-popover-template="'filtersPopover.tpl.html'"
-          popover-title="Variant Filters"
+          popover-title="Variant Display Options"
           popover-placement="left"
           popover-class="filters-content"
           class="btn btn-xs btn-default btn-block">
           <i class="glyphicon glyphicon-filter"></i>
-          Filter Variants
+          Display Options
         </a>
       </div>
       <div class="col-xs-2" ng-if="security.isAdmin || security.isEditor">
@@ -96,7 +96,7 @@
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showAccepted">
-      <span>Show variants with Accepted evidence</span>
+      <span>Show variants with any Accepted evidence</span>
     </label>
   </div>
   <div class="checkbox">

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -31,7 +31,7 @@
          if none or more than one, show them on a new row  -->
     <div class="col-xs-{{ variantGroups.length === 1 ? '8' : '12'}}">
       <ul class="variants">
-        <li ng-repeat="variant in variants | orderBy:'name' | filter:variantFilterFn as results">
+        <li ng-repeat="variant in variants | orderBy:'name' | filter:variantFilterFn | filter: {name: query} as results">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
         <li ng-if="results.length === 0">No matches exist for variant filters.</li>
@@ -75,7 +75,7 @@
           <span ng-bind="variantGroup.name">Variant Group Name</span> Group
         </a>
         <ul class="variants">
-          <li ng-repeat="variant in variantGroup.variants | orderBy:'name' | filter:variantFilterFn as results">
+          <li ng-repeat="variant in variantGroup.variants | orderBy:'name' | filter: variantFilterFn | filter: { name: query } as results">
             <ng-include src=" 'variantTag.tpl.html' "></ng-include>
           </li>
         </ul>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -34,7 +34,8 @@
         <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results"
           ng-show="(showAccepted && hasAcceptedItems(variant))
           || (showSubmitted && hasOnlySubmittedItems(variant))
-          || (showRejected && hasOnlyRejectedItems(variant))
+          || (showNoAccepted && hasNoAcceptedItems(variant))
+          || (showOnlyRejected && hasOnlyRejectedItems(variant))
           || variant.id == stateParams.variantId">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
@@ -95,19 +96,25 @@
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showAccepted">
-      <span>Show variants with accepted evidence</span>
+      <span>Show variants with Accepted evidence</span>
     </label>
   </div>
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showSubmitted">
-      <span>Show variants with only submitted evidence</span>
+      <span>Show variants with only Submitted evidence</span>
     </label>
   </div>
   <div class="checkbox">
     <label>
-      <input type="checkbox" ng-model="$parent.showRejected">
-      <span>Show variants with only rejected evidence</span>
+      <input type="checkbox" ng-model="$parent.showNoAccepted">
+      <span>Show variants with no Accepted evidence</span>
+    </label>
+  </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" ng-model="$parent.showOnlyRejected">
+      <span>Show variants with only Rejected evidence</span>
     </label>
   </div>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -31,12 +31,7 @@
          if none or more than one, show them on a new row  -->
     <div class="col-xs-{{ variantGroups.length === 1 ? '8' : '12'}}">
       <ul class="variants">
-        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results"
-          ng-show="(showAccepted && hasAcceptedItems(variant))
-          || (showSubmitted && hasSubmittedItems(variant))
-          || (showRejected && hasRejectedItems(variant))
-          || (showOrphans && hasNoItems(variant))
-          || variant.id == stateParams.variantId">
+        <li ng-repeat="variant in variants | orderBy:'name' | filter:variantFilterFn as results">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
         <li ng-if="results.length === 0">No matches exist for variant filters.</li>
@@ -80,12 +75,7 @@
           <span ng-bind="variantGroup.name">Variant Group Name</span> Group
         </a>
         <ul class="variants">
-          <li ng-repeat="variant in variantGroup.variants|orderBy:'name' | filter:{ name: query } as results"
-            ng-show="(showAccepted && hasAcceptedItems(variant))
-            || (showSubmitted && hasSubmittedItems(variant))
-            || (showRejected && hasRejectedItems(variant))
-            || (showOrphans && hasNoItems(variant))
-            || variant.id == stateParams.variantId">
+          <li ng-repeat="variant in variantGroup.variants | orderBy:'name' | filter:variantFilterFn as results">
             <ng-include src=" 'variantTag.tpl.html' "></ng-include>
           </li>
         </ul>
@@ -96,7 +86,7 @@
 
 <script type="text/ng-template" id="filtersPopover.tpl.html">
   <div>
-    <input ng-model="$parent.query" class="form-control filter" placeholder="Filter on variant name"/>
+    <input ng-model="$parent.query" class="form-control filter" placeholder="Filter on variant name" />
   </div>
   <div class="radio">
     <label>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -11,6 +11,7 @@
         <i uib-popover-template="'filtersPopover.tpl.html'"
           popover-title="Variant Filters"
           popover-placement="left"
+          popover-class="filters-content"
           class="glyphicon glyphicon-filter"></i>
       </div>
       <div class="col-xs-1" ng-if="security.isAdmin || security.isEditor">
@@ -26,7 +27,9 @@
          if none or more than one, show them on a new row  -->
     <div class="col-xs-{{ variantGroups.length === 1 ? '8' : '12'}}">
       <ul class="variants">
-        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results" ng-show="hasValidEvidenceItems(variant) || variant.id == stateParams.variantId || showAll === true">
+        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results" ng-show="hasAcceptedEvidenceItems(variant)
+          || variant.id == stateParams.variantId
+          || showRejected === true">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
         <li ng-if="results.length === 0">No variants match filter query.</li>
@@ -80,22 +83,26 @@
 </div>
 
 <script type="text/ng-template" id="filtersPopover.tpl.html">
-  <div class="settings-content">
-    <div>
-      <input ng-model="$parent.query" class="form-control filter" placeholder="Filter by variant name"/>
-    </div>
-    <div class="checkbox">
-      <label>
-        <input type="checkbox" ng-model="$parent.showSubmitted">
-        <span>Show variants with no evidence</span>
-      </label>
-    </div>
-    <div class="checkbox">
-      <label>
-        <input type="checkbox" ng-model="$parent.showRejected">
-        <span>Show variants with only rejected evidence</span>
-      </label>
-    </div>
+  <div>
+    <input ng-model="$parent.query" class="form-control filter" placeholder="Filter variant name"/>
+  </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" ng-model="$parent.showAccepted">
+      <span>Show variants with accepted evidence</span>
+    </label>
+  </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" ng-model="$parent.showSubmitted">
+      <span>Show variants with submitted evidence</span>
+    </label>
+  </div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" ng-model="$parent.showRejected">
+      <span>Show variants with rejected evidence</span>
+    </label>
   </div>
 </script>
 

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -1,7 +1,7 @@
 <div class="variantMenu {{ options.backgroundColor }}">
   <div class="title-bg">
     <div class="row">
-      <div class="col-xs-8">
+      <div ng-class="{'col-xs-8': security.isAdmin || security.isEditor, 'col-xs-10': !(security.isAdmin || security.isEditor)}">
         <h4 class="title">
           <span ng-bind="gene.name"></span> Variants
           <span ng-if="variantGroups.length > 0">&amp; Variant Group{{variantGroups.length > 1 ? 's' : ''}}</span>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -1,30 +1,17 @@
 <div class="variantMenu {{ options.backgroundColor }}">
   <div class="title-bg">
     <div class="row">
-      <div class="col-xs-5">
+      <div class="col-xs-10">
         <h4 class="title">
           <span ng-bind="gene.name"></span> Variants
           <span ng-if="variantGroups.length > 0">&amp; Variant Group{{variantGroups.length > 1 ? 's' : ''}}</span>
         </h4>
       </div>
-      <div class="col-xs-4 checkbox-field">
-        <div class="row">
-          <div class="col-xs-6">
-            <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
-              <label for="showAll">Show&nbsp;Rejected:</label>&nbsp;&nbsp;
-              <input type="checkbox" id="showAll" ng-model="showAll">
-            </div>
-          </div>
-          <div class="col-xs-6">
-            <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
-              <label for="showAll">Show&nbsp;Submitted:</label>&nbsp;&nbsp;
-              <input type="checkbox" id="showAll" ng-model="showAll">
-            </div>
-          </div>
-        </div>
-      </div>
-      <div ng-class="{'col-xs-2': security.isAdmin || security.isEditor, 'col-xs-4': !(security.isAdmin || security.isEditor)}">
-        <input ng-model="query" class="form-control filter" placeholder="filter variants..." aria-label="filter friends" />
+      <div class="col-xs-1" style="text-align: right;">
+        <i uib-popover-template="'filtersPopover.tpl.html'"
+          popover-title="Variant Filters"
+          popover-placement="left"
+          class="glyphicon glyphicon-filter"></i>
       </div>
       <div class="col-xs-1" ng-if="security.isAdmin || security.isEditor">
         <a ng-show="security.isAdmin || security.isEditor" ng-href="{{ addVarGroupUrl }}" class="btn btn-xs btn-default btn-block" style="font-size: 80%;">
@@ -56,15 +43,15 @@
 
   <script type="text/ng-template" id="variantTag.tpl.html">
     <span uib-tooltip-template="'variantTagTooltip.tpl.html'">
-    <a ui-sref="events.genes.summary.variants.summary({ geneId: variant.gene_id, variantId: variant.id, '#': 'variant' })"
-       class="variant-tag"
-       ng-class="{ statusRejected: !hasValidEvidenceItems(variant), active: variant.id == stateParams.variantId }">
-      <i class="glyphicon glyphicon-exclamation-sign pending-alert"
-         ng-if="variant.statuses.pending_evidence_count > 0 || variant.statuses.open_change_count > 0"
-      ng-class="{'pending-changes': variant.statuses.open_change_count > 0, 'pending-evidence': variant.statuses.pending_evidence_count > 0, 'pending-both': variant.statuses.open_change_count > 0 && variant.statuses.pending_evidence_count > 0}"></i>
-      <span ng-bind-html="variant.name | highlightSearch:query" class="variant-name">Variant Name</span>
-    <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
-    </a>
+      <a ui-sref="events.genes.summary.variants.summary({ geneId: variant.gene_id, variantId: variant.id, '#': 'variant' })"
+        class="variant-tag"
+        ng-class="{ statusRejected: !hasValidEvidenceItems(variant), active: variant.id == stateParams.variantId }">
+        <i class="glyphicon glyphicon-exclamation-sign pending-alert"
+          ng-if="variant.statuses.pending_evidence_count > 0 || variant.statuses.open_change_count > 0"
+          ng-class="{'pending-changes': variant.statuses.open_change_count > 0, 'pending-evidence': variant.statuses.pending_evidence_count > 0, 'pending-both': variant.statuses.open_change_count > 0 && variant.statuses.pending_evidence_count > 0}"></i>
+        <span ng-bind-html="variant.name | highlightSearch:query" class="variant-name">Variant Name</span>
+        <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
+      </a>
     </span>
   </script>
 
@@ -72,7 +59,7 @@
     <span>
       Evidence Items: {{ variant.evidence_item_statuses.accepted_count }}<br/>
       <span ng-if="variant.statuses.pending_evidence_count > 0" style="display: block;">Has {{ variant.statuses.pending_evidence_count }} pending evidence</span>
-    <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
+      <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
     </span>
   </script>
 
@@ -90,8 +77,44 @@
       </div>
     </div>
   </script>
-  <script type="text/ng-template " id="/variantTooltip.tpl.html ">
-    <div>
-    </div>
-  </script>
 </div>
+
+<script type="text/ng-template" id="filtersPopover.tpl.html">
+  <div class="settings-content">
+    <div>
+      <input ng-model="$parent.query" class="form-control filter" placeholder="Filter by variant name"/>
+    </div>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" ng-model="$parent.showSubmitted">
+        <span>Show variants with no evidence</span>
+      </label>
+    </div>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" ng-model="$parent.showRejected">
+        <span>Show variants with only rejected evidence</span>
+      </label>
+    </div>
+  </div>
+</script>
+
+<script type="text/ng-template" id="notused.tpl.html" >
+  <div class="row">
+    <div class="col-xs-6">
+      <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
+        <label for="showAll">Show&nbsp;Rejected:</label>&nbsp;&nbsp;
+        <input type="checkbox" id="showAll" ng-model="showSubmitted">
+      </div>
+    </div>
+    <div class="col-xs-6">
+      <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
+        <label for="showAll">Show&nbsp;Submitted:</label>&nbsp;&nbsp;
+        <input type="checkbox" id="showAll" ng-model="showRejected">
+      </div>
+    </div>
+  </div>
+  <div ng-class="{'col-xs-2': security.isAdmin || security.isEditor, 'col-xs-4': !(security.isAdmin || security.isEditor)}">
+    <input ng-model="query" class="form-control filter" placeholder="filter variants..." aria-label="filter friends" />
+  </div>
+</script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -1,11 +1,14 @@
 <div class="variantMenu {{ options.backgroundColor }}">
   <div class="title-bg">
     <div class="row">
-      <div ng-class="{'col-xs-8': security.isAdmin || security.isEditor, 'col-xs-10': !(security.isAdmin || security.isEditor)}">
+      <div ng-class="{'col-xs-6': security.isAdmin || security.isEditor, 'col-xs-8': !(security.isAdmin || security.isEditor)}">
         <h4 class="title">
           <span ng-bind="gene.name"></span> Variants
           <span ng-if="variantGroups.length > 0">&amp; Variant Group{{variantGroups.length > 1 ? 's' : ''}}</span>
         </h4>
+      </div>
+      <div class="col-xs-2" >
+        <input ng-model="query" class="form-control filter" placeholder="Filter by name" />
       </div>
       <div class="col-xs-2" style="text-align: right;">
         <a uib-popover-template="'filtersPopover.tpl.html'"
@@ -85,31 +88,28 @@
 </div>
 
 <script type="text/ng-template" id="filtersPopover.tpl.html">
-  <div>
-    <input ng-model="$parent.query" class="form-control filter" placeholder="Filter on variant name" />
-  </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="accepted">
-      <span>Show variants with editor reviewed evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
+      <span uib-tooltip="Includes only variants with accepted evidence">Show variants with editor reviewed evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="accepted_submitted">
-      <span>Show variants with editor reviewed evidence and/or evidence pending review <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
+      <span uib-tooltip="Includes variants with accepted and/or pending evidence">Show variants with editor reviewed evidence and/or evidence pending review <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="submitted">
-      <span>Show variants with evidence pending review <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
+      <span uib-tooltip="Includes variants with pending evidence">Show variants with evidence pending review <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="all">
-      <span>Show all variants <span class="count" >({{$parent.variants.length}})</span></span>
+      <span uib-tooltip="Includes variants with accepted, pending, rejected evidence, or no evidence at all (orphans)">Show all variants <span class="count" >({{$parent.variants.length}})</span></span>
     </label>
   </div>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -1,27 +1,33 @@
 <div class="variantMenu {{ options.backgroundColor }}">
   <div class="title-bg">
     <div class="row">
-      <div class="col-xs-6" >
+      <div class="col-xs-5">
         <h4 class="title">
           <span ng-bind="gene.name"></span> Variants
           <span ng-if="variantGroups.length > 0">&amp; Variant Group{{variantGroups.length > 1 ? 's' : ''}}</span>
         </h4>
       </div>
-      <div class="col-xs-2 show-all">
-        <div uib-tooltip="Toggle display of variants with no accepted evidence"
-             ng-show="hasHiddenVariants === true">
-          <label for="showAll">Show&nbsp;all:</label>&nbsp;&nbsp;<input type="checkbox"
-                                                                        id="showAll"
-                                                                        ng-model="showAll">
+      <div class="col-xs-4 checkbox-field">
+        <div class="row">
+          <div class="col-xs-6">
+            <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
+              <label for="showAll">Show&nbsp;Rejected:</label>&nbsp;&nbsp;
+              <input type="checkbox" id="showAll" ng-model="showAll">
+            </div>
+          </div>
+          <div class="col-xs-6">
+            <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
+              <label for="showAll">Show&nbsp;Submitted:</label>&nbsp;&nbsp;
+              <input type="checkbox" id="showAll" ng-model="showAll">
+            </div>
+          </div>
         </div>
       </div>
       <div ng-class="{'col-xs-2': security.isAdmin || security.isEditor, 'col-xs-4': !(security.isAdmin || security.isEditor)}">
         <input ng-model="query" class="form-control filter" placeholder="filter variants..." aria-label="filter friends" />
       </div>
-      <div class="col-xs-2" ng-if="security.isAdmin || security.isEditor">
-        <a ng-show="security.isAdmin || security.isEditor"
-           ng-href="{{ addVarGroupUrl }}"
-           class="btn btn-xs btn-default btn-block">
+      <div class="col-xs-1" ng-if="security.isAdmin || security.isEditor">
+        <a ng-show="security.isAdmin || security.isEditor" ng-href="{{ addVarGroupUrl }}" class="btn btn-xs btn-default btn-block" style="font-size: 80%;">
           Add Group
         </a>
       </div>
@@ -33,8 +39,7 @@
          if none or more than one, show them on a new row  -->
     <div class="col-xs-{{ variantGroups.length === 1 ? '8' : '12'}}">
       <ul class="variants">
-        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results"
-            ng-show="hasValidEvidenceItems(variant) || variant.id == stateParams.variantId || showAll === true">
+        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results" ng-show="hasValidEvidenceItems(variant) || variant.id == stateParams.variantId || showAll === true">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
         <li ng-if="results.length === 0">No variants match filter query.</li>
@@ -58,36 +63,34 @@
          ng-if="variant.statuses.pending_evidence_count > 0 || variant.statuses.open_change_count > 0"
       ng-class="{'pending-changes': variant.statuses.open_change_count > 0, 'pending-evidence': variant.statuses.pending_evidence_count > 0, 'pending-both': variant.statuses.open_change_count > 0 && variant.statuses.pending_evidence_count > 0}"></i>
       <span ng-bind-html="variant.name | highlightSearch:query" class="variant-name">Variant Name</span>
-      <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
+    <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
     </a>
     </span>
   </script>
 
-  <script type="text/ng-template" id="variantTagTooltip.tpl.html" >
+  <script type="text/ng-template" id="variantTagTooltip.tpl.html">
     <span>
       Evidence Items: {{ variant.evidence_item_statuses.accepted_count }}<br/>
       <span ng-if="variant.statuses.pending_evidence_count > 0" style="display: block;">Has {{ variant.statuses.pending_evidence_count }} pending evidence</span>
-      <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
+    <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
     </span>
   </script>
 
   <script type="text/ng-template" id="variantGroupBlock.tpl.html">
     <div class="col-xs-4">
       <div class="variant-group" ng-class="{ 'active': $state.includes('events.genes.summary.variantGroups', {geneId: gene.id, variantGroupId: variantGroup.id})}">
-        <a class="group-title"
-           ng-class="{ active: variantGroup.id == stateParams.variantGroupId }"
-           ui-sref="events.genes.summary.variantGroups.summary({ geneId: gene.id, variantGroupId: variantGroup.id, '#': 'variant-group' })">
+        <a class="group-title" ng-class="{ active: variantGroup.id == stateParams.variantGroupId }" ui-sref="events.genes.summary.variantGroups.summary({ geneId: gene.id, variantGroupId: variantGroup.id, '#': 'variant-group' })">
           <span ng-bind="variantGroup.name">Variant Group Name</span> Group
         </a>
         <ul class="variants">
-          <li ng-repeat="variant in variantGroup.variants|orderBy:'name' | filter:{ name: query } as results"" ng-show="hasValidEvidenceItems(variant)">
-            <ng-include src="'variantTag.tpl.html'"></ng-include>
+          <li ng-repeat="variant in variantGroup.variants|orderBy:'name' | filter:{ name: query } as results" " ng-show="hasValidEvidenceItems(variant) ">
+            <ng-include src=" 'variantTag.tpl.html' "></ng-include>
           </li>
         </ul>
       </div>
     </div>
   </script>
-  <script type="text/ng-template" id="/variantTooltip.tpl.html">
+  <script type="text/ng-template " id="/variantTooltip.tpl.html ">
     <div>
     </div>
   </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -98,29 +98,28 @@
   <div>
     <input ng-model="$parent.query" class="form-control filter" placeholder="Filter on variant name"/>
   </div>
-  <div class="checkbox">
+  <div class="radio">
     <label>
-      <input type="checkbox" ng-model="$parent.showAccepted">
+      <input type="radio" ng-model="$parent.options_filter" value="accepted">
       <span>Show variants with editor reviewed evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
     </label>
   </div>
-  <div class="checkbox">
+  <div class="radio">
     <label>
-      <input type="checkbox" ng-model="$parent.showSubmitted">
+      <input type="radio" ng-model="$parent.options_filter" value="accepted_submitted">
       <span>Show variants with editor reviewed evidence and/or evidence pending review <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
-  <div class="checkbox">
+  <div class="radio">
     <label>
-      <input type="checkbox" ng-model="$parent.showNoAccepted">
+      <input type="radio" ng-model="$parent.options_filter" value="submitted">
       <span>Show variants with evidence pending review <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
-  <div class="checkbox">
+  <div class="radio">
     <label>
-      <input type="checkbox" ng-model="$parent.showOnlyRejected">
+      <input type="radio" ng-model="$parent.options_filter" value="all">
       <span>Show all variants <span class="count" >({{$parent.variants.length}})</span></span>
     </label>
   </div>
-  <pre ng-bind="$parent.evidence_category_counts | json" ></pre>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -80,7 +80,12 @@
           <span ng-bind="variantGroup.name">Variant Group Name</span> Group
         </a>
         <ul class="variants">
-          <li ng-repeat="variant in variantGroup.variants|orderBy:'name' | filter:{ name: query } as results" " ng-show="hasValidEvidenceItems(variant) ">
+          <li ng-repeat="variant in variantGroup.variants|orderBy:'name' | filter:{ name: query } as results"
+            ng-show="(showAccepted && hasAcceptedItems(variant))
+            || (showSubmitted && hasSubmittedItems(variant))
+            || (showRejected && hasRejectedItems(variant))
+            || (showOrphans && hasNoItems(variant))
+            || variant.id == stateParams.variantId">
             <ng-include src=" 'variantTag.tpl.html' "></ng-include>
           </li>
         </ul>
@@ -96,45 +101,26 @@
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showAccepted">
-      <span>Show variants with any Accepted evidence</span>
+      <span>Show variants with editor reviewed evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
     </label>
   </div>
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showSubmitted">
-      <span>Show variants with only Submitted evidence</span>
+      <span>Show variants with editor reviewed evidence and/or evidence pending review <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showNoAccepted">
-      <span>Show variants with no Accepted evidence</span>
+      <span>Show variants with evidence pending review <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
     </label>
   </div>
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showOnlyRejected">
-      <span>Show variants with only Rejected evidence</span>
+      <span>Show all variants <span class="count" >({{$parent.variants.length}})</span></span>
     </label>
   </div>
-</script>
-
-<script type="text/ng-template" id="notused.tpl.html" >
-  <div class="row">
-    <div class="col-xs-6">
-      <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
-        <label for="showAll">Show&nbsp;Rejected:</label>&nbsp;&nbsp;
-        <input type="checkbox" id="showAll" ng-model="showSubmitted">
-      </div>
-    </div>
-    <div class="col-xs-6">
-      <div uib-tooltip="Toggle display of variants with no accepted evidence" ng-show="hasHiddenVariants === true">
-        <label for="showAll">Show&nbsp;Submitted:</label>&nbsp;&nbsp;
-        <input type="checkbox" id="showAll" ng-model="showRejected">
-      </div>
-    </div>
-  </div>
-  <div ng-class="{'col-xs-2': security.isAdmin || security.isEditor, 'col-xs-4': !(security.isAdmin || security.isEditor)}">
-    <input ng-model="query" class="form-control filter" placeholder="filter variants..." aria-label="filter friends" />
-  </div>
+  <pre ng-bind="$parent.evidence_category_counts | json" ></pre>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -1,21 +1,25 @@
 <div class="variantMenu {{ options.backgroundColor }}">
   <div class="title-bg">
     <div class="row">
-      <div class="col-xs-10">
+      <div class="col-xs-8">
         <h4 class="title">
           <span ng-bind="gene.name"></span> Variants
           <span ng-if="variantGroups.length > 0">&amp; Variant Group{{variantGroups.length > 1 ? 's' : ''}}</span>
         </h4>
       </div>
-      <div class="col-xs-1" style="text-align: right;">
-        <i uib-popover-template="'filtersPopover.tpl.html'"
+      <div class="col-xs-2" style="text-align: right;">
+        <a uib-popover-template="'filtersPopover.tpl.html'"
           popover-title="Variant Filters"
           popover-placement="left"
           popover-class="filters-content"
-          class="glyphicon glyphicon-filter"></i>
+          class="btn btn-xs btn-default btn-block">
+          <i class="glyphicon glyphicon-filter"></i>
+          Filter Variants
+        </a>
       </div>
-      <div class="col-xs-1" ng-if="security.isAdmin || security.isEditor">
-        <a ng-show="security.isAdmin || security.isEditor" ng-href="{{ addVarGroupUrl }}" class="btn btn-xs btn-default btn-block" style="font-size: 80%;">
+      <div class="col-xs-2" ng-if="security.isAdmin || security.isEditor">
+        <a ng-show="security.isAdmin || security.isEditor" ng-href="{{ addVarGroupUrl }}" class="btn btn-xs btn-cell-add btn-block">
+          <i class="glyphicon glyphicon-plus"></i>
           Add Group
         </a>
       </div>
@@ -27,12 +31,14 @@
          if none or more than one, show them on a new row  -->
     <div class="col-xs-{{ variantGroups.length === 1 ? '8' : '12'}}">
       <ul class="variants">
-        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results" ng-show="hasAcceptedEvidenceItems(variant)
-          || variant.id == stateParams.variantId
-          || showRejected === true">
+        <li ng-repeat="variant in variants | orderBy:'name' | filter:{ name: query } as results"
+          ng-show="(showAccepted && hasAcceptedItems(variant))
+          || (showSubmitted && hasOnlySubmittedItems(variant))
+          || (showRejected && hasOnlyRejectedItems(variant))
+          || variant.id == stateParams.variantId">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
-        <li ng-if="results.length === 0">No variants match filter query.</li>
+        <li ng-if="results.length === 0">No matches exist for variant filters.</li>
       </ul>
     </div>
     <div ng-if="variantGroups.length === 1" style="margin-top: 8px;">
@@ -84,7 +90,7 @@
 
 <script type="text/ng-template" id="filtersPopover.tpl.html">
   <div>
-    <input ng-model="$parent.query" class="form-control filter" placeholder="Filter variant name"/>
+    <input ng-model="$parent.query" class="form-control filter" placeholder="Filter on variant name"/>
   </div>
   <div class="checkbox">
     <label>
@@ -95,13 +101,13 @@
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showSubmitted">
-      <span>Show variants with submitted evidence</span>
+      <span>Show variants with only submitted evidence</span>
     </label>
   </div>
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="$parent.showRejected">
-      <span>Show variants with rejected evidence</span>
+      <span>Show variants with only rejected evidence</span>
     </label>
   </div>
 </script>


### PR DESCRIPTION
The 'show all' checkbox which originally toggled the display of rejected evidence items has been expanded to three checkboxes applied with OR logic for each predicate:

[] Show variants with accepted evidence
[] Show variants with only submitted evidence - shows variants with submitted, but no accepted evidence
[] Show variants with only rejected evidence - shows variants that have only rejected evidence items

![screenshot 2018-10-08 10 28 39](https://user-images.githubusercontent.com/132909/46618689-d84c4a00-cae5-11e8-82d2-fe9d719a06fb.png)
![screenshot 2018-10-08 10 29 04](https://user-images.githubusercontent.com/132909/46618710-e1d5b200-cae5-11e8-8a19-86e9eabe8f34.png)
![screenshot 2018-10-08 10 29 37](https://user-images.githubusercontent.com/132909/46618727-ec904700-cae5-11e8-9767-96f33545a63c.png)
![screenshot 2018-10-08 10 29 50](https://user-images.githubusercontent.com/132909/46618731-f0bc6480-cae5-11e8-9912-aac1518d5be2.png)

