### PR TITLE
evidence grid status filter defaults now working properly - rejected evidence now hidden

### DIFF
--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -436,7 +436,7 @@
       $scope.$watchCollection('evidence', function(evidence) {
         console.log('ui-grid watchCollection called.');
         // if we get an evidence list that is rejected items only, let's show those instead of showing nothing
-        if(_.every(evidence, 'status', 'rejected')) {
+        if(_.every(evidence, {status: 'rejected' })) {
           statusFilters = ['accepted', 'submitted', 'rejected'];
         } else if (!_.includes(statusFilters, 'rejected')) {
           statusFilters = ['accepted', 'submitted'];


### PR DESCRIPTION
Rejected evidence items were being shown by default; this update updates a function call to a library function whos API had updated, overwriting defaults before grid was rendered.