### PR TITLE
evidence selector grid now sends sort_priority properly (fixes #957)

### DIFF
--- a/src/app/views/events/common/evidenceSelector/evidenceSelector.js
+++ b/src/app/views/events/common/evidenceSelector/evidenceSelector.js
@@ -635,8 +635,12 @@
       }
 
       if (sorting.length > 0) {
-        _.each(sorting, function(sort) {
+        request.sort_priority = '';
+        var length = sorting.length;
+        _.each(sorting, function(sort, index) {
           request['sorting[' + sort.field + ']'] = sort.direction;
+          request.sort_priority += sort.field;
+          if (index+1 < length) { request.sort_priority += ',';}
         });
       }
       return Datatables.query(request);


### PR DESCRIPTION
Provides a client-side fix for #957 - grid in the evidence selector field's evidence grid now properly sends sort_priority as query in datatables request