### PR TITLE
added sort option to variant menu display options popover; improved popover close action

### DIFF
--- a/src/app/pages/about.tpl.html
+++ b/src/app/pages/about.tpl.html
@@ -108,6 +108,7 @@
         <li><a href="http://euformatics.com/ongs/" title="Omnomics NGS project" target="_blank">Euformatics OmnomicsNGS</a></li>
         <li><a href="http://gemini.readthedocs.io/en/latest/" title="gemini project" target="_blank">Gemini</a></li>
         <li><a href="http://www.genecards.org/" title="gene cards project" target="_blank">Gene Cards</a></li>
+        <li><a href="https://www.genoox.com/" title="Genoox corporation" target="_blank">Genoox</a></li>
         <li><a href="https://dcc.icgc.org/" title="ICGC data portal" target="_blank">International Cancer Genome Consortium (ICGC) Data Portal</a></li>
         <li><a href="http://tgex.genecards.org/" title="tgex.genecards.org project" target="_blank">LifeMap Sciences TGex NGS Analysis & Interpretation Platform</a></li>
         <li><a href="https://mgend.med.kyoto-u.ac.jp/" title="MGeND project" target="_blank">Medical Genomics Japan Variant Database (MGeND)</a></li>

--- a/src/app/pages/help_intro.tpl.html
+++ b/src/app/pages/help_intro.tpl.html
@@ -1,6 +1,6 @@
 <div>
   <h3 class="subtitle">Introduction to CIViC</h3>
-
+  <p>To get started using and contributing to CIViC, we recommend that you <a href="#tutorials">review the Video Tutorials below</a>. These videos cover CIViC and it's goals, finding documentation and help resources, browsing and searching knowledgebase contents, adding evidence to CIViC, and editing CIViC evidence.</p>
   <p>For a primer on the fundamentals of cancer variant interpretation, we highly recommend that new users start by reading the CIViC paper and four recently published Standards and Guidelines proposals:
     <li><a href="http://www.nature.com/ng/journal/v49/n2/full/ng.3774.html" title="Nature Genetics - CIViC commentary" target="_blank">CIViC is a community knowledgebase for expert crowdsourcing the clinical interpretation of variants in cancer</a>.</li>
     <li><a href="https://www.ncbi.nlm.nih.gov/pubmed/25741868" title="PubMed - ACMG variant guidelines publication" target="_blank">ACMG/AMP - Standards and guidelines for the interpretation of sequence variants</a>.</li>
@@ -13,32 +13,55 @@
   <h3>The CIViC Ecosystem of Collaborators, Moderators and Other Stakeholders</h3>
   <p>The CIViC project aims to facilitate a collaborative ecosystem of research scientists, clinical scientists, and patient advocates dedicated to curating an accurate and relevant database of clinical interpretations of cancer variants. The diagram below shows how the various stakeholders in the CIViC ecosystem collaborate to curate the database.</p>
   <p class="diagram">
-        <img
-          src="assets/images/GP-125_CIViC_main-process_v5b.png"
-          class="img-fluid img-popup" width="100%" height="100%"
-          alt="CIViC Schema Diagram"
-          ng-click="vm.imgPopup('assets/images/GP-125_CIViC_main-process_v5b.png')"/>
+    <img
+      src="assets/images/GP-125_CIViC_main-process_v5b.png"
+      class="img-fluid img-popup" width="100%" height="100%"
+      alt="CIViC Schema Diagram"
+      ng-click="vm.imgPopup('assets/images/GP-125_CIViC_main-process_v5b.png')"/>
   </p>
 
-  <a name="screencasts"></a>
-  <h3 class="subtitle">CIViC Screencasts</h3>
-  <p>To learn more about CIViC please review the CIViC documentation using the menu to the left. Some instructional videos describing how to use CIViC are below.</p>
-
+  <a name="tutorials"></a>
+  <h3 class="subtitle">CIViC Video Tutorials</h3>
+  <p>The videos below offer overviews of the CIViC application, and are recommended viewing for users wishing to gain a quick understanding of basic CIViC interface elements and workflows.</p>
+  <h4>CIViC - Getting Started</h4>
+  <p>This video covers:</p>
+  <ul>
+    <li>Description of CIViC and its goals</li>
+    <li>Navigating through CIViC's core pages</li>
+    <li>Browsing, searching, and consuming knowledgebase content</li>
+  </ul>
   <div class="embed-responsive embed-responsive-16by9">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/Vr0BDUKkDeI" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
-  <hr />
+  <hr/>
+  <h4>Adding CIViC Evidence</h4>
+  <p>This video covers:</p>
+  <ul>
+    <li>Scanning a publication for curatable details</li>
+    <li>Signing into CIViC to Add Evidence</li>
+    <li>Walking through the Add Evidence form</li>
+    <li>Viewing the submitted evidence</li>
+  </ul>
   <div class="embed-responsive embed-responsive-16by9">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/od5Tgdfo6Qs" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
-  <hr />
+  <hr/>
+  <h4>Editing entities in CIViC</h4>
+  <p>This video covers:</p>
+  <ul>
+    <li>Navigating to an entity's Edit Form</li>
+    <li>Importance of edit comments</li>
+    <li>Identifying entities with pending changes</li>
+    <li>Navigating to an entity's suggested changes</li>
+    <li>Reviewing entity revisions</li>
+  </ul>
   <div class="embed-responsive embed-responsive-16by9">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/uss4R20ymPA" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
   <!---
-  <div class="embed-responsive embed-responsive-16by9">
-    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/KImI_oNYtyc" frameborder="0" allowfullscreen></iframe>
-  </div>
-  --->
+       <div class="embed-responsive embed-responsive-16by9">
+       <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/KImI_oNYtyc" frameborder="0" allowfullscreen></iframe>
+       </div>
+     --->
 
 </div>

--- a/src/app/views/events/common/assertionGrid/assertionGrid.tpl.html
+++ b/src/app/views/events/common/assertionGrid/assertionGrid.tpl.html
@@ -18,6 +18,7 @@
       <button
         class="btn btn-default btn-xs pull-right col-key btn-block"
         uib-popover-template="ctrl.exportPopover.templateUrl"
+        popover-trigger="'outsideClick'"
         ng-disabled="ctrl.assertionGridOptions.data.length < 1"
         popover-placement="bottom">
         <span class="glyphicon glyphicon-export"

--- a/src/app/views/events/common/editableField.tpl.html
+++ b/src/app/views/events/common/editableField.tpl.html
@@ -2,36 +2,37 @@
   <span ng-switch="ctrl.isAuthenticated()" >
     <span ng-switch-when="false" >
       <a class="btn  btn-xs btn-edit-entity"
-         uib-tooltip="Please sign in to edit this {{type|lowercase}}"
-         tooltip-append-to-body="true"
-         ng-disabled="true">
+        uib-tooltip="Please sign in to edit this {{type|lowercase}}"
+        tooltip-append-to-body="true"
+        ng-disabled="true">
         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
       </a>
       <a class="btn btn-xs btn-flag"
-         ng-class="{'flagged': ctrl.hasActiveFlag}"
-         uib-popover-template="'flagPopover.tpl.html'"
-         popover-title="Flag {{type}} {{name}} "
-         popover-placement="{{ctrl.popoverPlacement}}"
-         uib-tooltip="{{ctrl.hasActiveFlag ? 'This ' + (type|lowercase) + ' has been flagged' : 'Sign in to flag this ' + (type|lowercase)}}":
-         tooltip-append-to-body="true">
+        ng-class="{'flagged': ctrl.hasActiveFlag}"
+        uib-popover-template="'flagPopover.tpl.html'"
+        popover-trigger="'outsideClick'"
+        popover-title="Flag {{type}} {{name}} "
+        popover-placement="{{ctrl.popoverPlacement}}"
+        uib-tooltip="{{ctrl.hasActiveFlag ? 'This ' + (type|lowercase) + ' has been flagged' : 'Sign in to flag this ' + (type|lowercase)}}":
+        tooltip-append-to-body="true">
         <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
       </a>
     </span>
     <span ng-switch-when="true" >
       <a class="btn btn-xs btn-edit-entity"
-         ng-class="{ 'active': ctrl.active === true }"
-         uib-tooltip="Edit this {{type|lowercase}}"
-         uib-tooltip-append-to-body="true"
-         ng-click="ctrl.edit()">
+        ng-class="{ 'active': ctrl.active === true }"
+        uib-tooltip="Edit this {{type|lowercase}}"
+        uib-tooltip-append-to-body="true"
+        ng-click="ctrl.edit()">
         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
       </a>
       <a class="btn  btn-xs btn-flag"
-         ng-class="{'flagged': ctrl.hasActiveFlag}"
-         uib-tooltip="{{ctrl.hasActiveFlag ? 'This ' + (type|lowercase) + ' has been flagged' : 'Flag this ' + (type|lowercase)}}"
-         tooltip-append-to-body="true"
-         uib-popover-template="'flagPopover.tpl.html'"
-         popover-title="Flag {{type}} {{name}} "
-         popover-placement="{{ctrl.popoverPlacement}}">
+        ng-class="{'flagged': ctrl.hasActiveFlag}"
+        uib-tooltip="{{ctrl.hasActiveFlag ? 'This ' + (type|lowercase) + ' has been flagged' : 'Flag this ' + (type|lowercase)}}"
+        tooltip-append-to-body="true"
+        uib-popover-template="'flagPopover.tpl.html'"
+        popover-title="Flag {{type}} {{name}} "
+        popover-placement="{{ctrl.popoverPlacement}}">
         <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
       </a>
     </span>
@@ -50,18 +51,18 @@
           <div class="col-xs-12" >
             <div class="form-group">
               <textarea ng-model="ctrl.newFlag.comment.text" class="form-control flag-comment" rows="2"
-              ng-attr-placeholder="Flag this {{type|lowercase}} by describing why it requires the attention of the CIViC editors."></textarea>
+                ng-attr-placeholder="Flag this {{type|lowercase}} by describing why it requires the attention of the CIViC editors."></textarea>
             </div>
           </div>
         </div>
         <div class="row">
           <div class="col-xs-12 panel-buttons" >
             <button type="submit"
-               class="btn btn-xs btn-danger"
-               ng-click="ctrl.submit(ctrl.newFlag)"
-               ng-disabled="ctrl.newFlag.comment.text.length < 3"
-               uib-tooltip-enable="ctrl.newFlag.comment.text.length < 3"
-               uib-tooltip="Please add comment before submitting flag.">
+              class="btn btn-xs btn-danger"
+              ng-click="ctrl.submit(ctrl.newFlag)"
+              ng-disabled="ctrl.newFlag.comment.text.length < 3"
+              uib-tooltip-enable="ctrl.newFlag.comment.text.length < 3"
+              uib-tooltip="Please add comment before submitting flag.">
               Flag
             </button>
           </div>

--- a/src/app/views/events/common/entityTabs.tpl.html
+++ b/src/app/views/events/common/entityTabs.tpl.html
@@ -7,22 +7,23 @@
       </div>
       <div class="col-xs-12 col-md-6 tabs {{ viewBackground }}">
         <uib-tabset class="tab-container"
-                type="{{'tabs'}}"
-                vertical="{{vertical}}"
-                justified="{{justified}}">
+          type="{{'tabs'}}"
+          vertical="{{vertical}}"
+          justified="{{justified}}">
           <uib-tab classes="tab"
-               ng-repeat="tab in tabs"
-               heading="{{tab.heading}}"
-               active="tab.active"
-               disable="tab.disabled"
-               ng-click="go(tab)">
+            ng-repeat="tab in tabs"
+            heading="{{tab.heading}}"
+            active="tab.active"
+            disable="tab.disabled"
+            ng-click="go(tab)">
           </uib-tab>
         </uib-tabset>
         <div class="tab-info">
           <i uib-popover-template="'settingsPopover.tpl.html'"
-             popover-title="{{vm.type}} Settings"
-             popover-placement="left"
-             class="glyphicon glyphicon-cog"></i>
+            popover-trigger="'outsideClick'"
+            popover-title="{{vm.type}} Settings"
+            popover-placement="left"
+            class="glyphicon glyphicon-cog"></i>
         </div>
       </div>
     </div>
@@ -39,8 +40,8 @@
       <div class="col-xs-1">
         <div ng-if="vm.pendingFields.length > 0" class="pending-notice">
           <span uib-tooltip-template="'pendingTooltip.tpl.html'"
-                tooltip-placement="left"
-                tooltip-append-to-body="true">
+            tooltip-placement="left"
+            tooltip-append-to-body="true">
             <i class="glyphicon glyphicon-exclamation-sign pending-changes"></i>
           </span>
         </div>
@@ -51,23 +52,23 @@
 
 <script type="text/ng-template" id="entityTitle.tpl.html">
   <h3 editable-field class="tab-name"
-      type="vm.type"
-      name="vm.name"
-      entity-view-model="entityViewModel"
-      entity-view-revisions="entityViewRevisions"
-      entity-view-options="entityViewOptions">
+    type="vm.type"
+    name="vm.name"
+    entity-view-model="entityViewModel"
+    entity-view-revisions="entityViewRevisions"
+    entity-view-options="entityViewOptions">
     <span ng-bind="vm.type" class="entity-type">Entity</span>
     <span ng-bind="vm.name" class="entity-name">Name</span>
   </h3>
 </script>
 
 <script type="text/ng-template" id="pendingTooltip.tpl.html">
-<div>
+  <div>
     This {{ vm.type.toLowerCase() }} has pending revisions to:
     <ul>
       <li ng-repeat="field in vm.pendingFields">{{ field | keyToLabel}}</li>
     </ul>
-</div>
+  </div>
 </script>
 
 <script type="text/ng-template" id="settingsPopover.tpl.html">

--- a/src/app/views/events/common/entityUsersPopover.tpl.html
+++ b/src/app/views/events/common/entityUsersPopover.tpl.html
@@ -3,7 +3,7 @@
     class="btn btn-xs btn-default"
     uib-popover-template="vm.usersPopover.templateUrl"
     popover-placement="left"
-
+    popover-trigger="'outsideClick'"
     popover-title="{{vm.usersPopover.title}}">
     <i class="glyphicon glyphicon-user"></i>
   </span>

--- a/src/app/views/events/common/evidenceGrid.tpl.html
+++ b/src/app/views/events/common/evidenceGrid.tpl.html
@@ -24,6 +24,7 @@
       <button
         class="btn btn-default btn-xs pull-right col-key btn-block"
         uib-popover-template="ctrl.exportPopover.templateUrl"
+        popover-trigger="'outsideClick'"
         ng-disabled="ctrl.evidenceGridOptions.data.length < 1"
         popover-placement="bottom">
         <span class="glyphicon glyphicon-export"

--- a/src/app/views/events/common/geneGrid/geneGrid.tpl.html
+++ b/src/app/views/events/common/geneGrid/geneGrid.tpl.html
@@ -18,6 +18,7 @@
       <button
         class="btn btn-default btn-xs pull-right col-key btn-block"
         uib-popover-template="ctrl.exportPopover.templateUrl"
+        popover-trigger="'outsideClick'"
         ng-disabled="ctrl.geneGridOptions.data.length < 1"
         popover-placement="bottom">
         <span class="glyphicon glyphicon-export"

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -56,6 +56,31 @@
 
     var addVarGroupUrlBase = $scope.addVarGroupUrl = 'add/variantGroup';
 
+    $scope.order = {
+      field: 'name',
+      reverse: false
+    };
+
+    $scope.sortOptions = [
+      { value: true, label: 'descending' },
+      { value: false, label: 'ascending' }
+    ];
+
+    $scope.variantMenuOrderBy = function(variant) {
+      var order = 0;
+      switch ($scope.order.field) {
+      case 'name':
+        order = variant.name;
+        break;
+      case 'position':
+        order = variant.coordinates.start;
+        break;
+      default:
+        order = variant.name;
+      }
+      return order;
+    };
+
     $scope.$watchCollection('stateParams', function(stateParams){
       if(_.has(stateParams, 'geneId')) {
         $scope.addVarGroupUrl = addVarGroupUrlBase + '?geneId=' + stateParams.geneId;
@@ -81,12 +106,17 @@
     $scope.$watchCollection(
       function() { return Genes.data.variantsStatus.variants; },
       function(variants){
+        $scope.nullCoordVars = [];
         _.forEach(variants, function(variant) {
           var counts = variant.evidence_item_statuses;
-          if (counts.accepted_count > 0) { $scope.evidence_category_counts.accepted++;}
-          if (counts.submitted_count > 0) { $scope.evidence_category_counts.submitted++;}
+          var hasAccepted = false;
+          var hasSubmitted = false;
+          if (counts.accepted_count > 0) { $scope.evidence_category_counts.accepted++; hasAccepted = true; }
+          if (counts.submitted_count > 0) { $scope.evidence_category_counts.submitted++; hasSubmitted = true; }
           if (counts.rejected_count > 0) { $scope.evidence_category_counts.rejected++;}
           if (counts.accepted_count === 0 && counts.submitted_count === 0 && counts.rejected_count === 0) { $scope.evidence_category_counts.orphaned++;}
+          // if variant has no start coords, add to nullCoordVars list, to be displayed in display options sort menu
+          if (!variant.coordinates.start && (hasAccepted || hasSubmitted)) { $scope.nullCoordVars.push(variant.name); }
         });
         $scope.variants = variants;
       });

--- a/src/app/views/events/genes/summary/variantMenu.less
+++ b/src/app/views/events/genes/summary/variantMenu.less
@@ -39,6 +39,11 @@
       font-style: oblique;
     }
   }
+  .null-coord-note {
+    margin-top: 5px;
+    font-style: oblique;
+    color: #666;
+  }
   .sub-title {
     font-weight: bold;
     text-decoration: underline;

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -11,7 +11,7 @@
         <input ng-model="query" class="form-control filter" placeholder="Filter by name" />
       </div>
       <div class="col-xs-2" style="text-align: right;">
-        <a uib-popover-template="'filtersPopover.tpl.html'"
+        <a uib-popover-template="'displayOptionsPopover.tpl.html'"
           popover-title="Variant Display Options"
           popover-placement="left"
           popover-class="filters-content"
@@ -34,7 +34,7 @@
          if none or more than one, show them on a new row  -->
     <div class="col-xs-{{ variantGroups.length === 1 ? '8' : '12'}}">
       <ul class="variants">
-        <li ng-repeat="variant in variants | orderBy:'name' | filter:variantFilterFn | filter: {name: query} as results">
+        <li ng-repeat="variant in variants | orderBy:variantMenuOrderBy:order.reverse | filter:variantFilterFn | filter: {name: query} as results">
           <ng-include src="'variantTag.tpl.html'"></ng-include>
         </li>
         <li ng-if="results.length === 0">No matches exist for variant filters.</li>
@@ -87,7 +87,7 @@
   </script>
 </div>
 
-<script type="text/ng-template" id="filtersPopover.tpl.html">
+<script type="text/ng-template" id="displayOptionsPopover.tpl.html">
   <div class="radio">
     <label>
       <input type="radio" ng-model="$parent.options_filter" value="accepted">
@@ -111,5 +111,21 @@
       <input type="radio" ng-model="$parent.options_filter" value="all">
       <span uib-tooltip="Includes all variants">Show all: variants with accepted, submitted, rejected, and/or no evidence (orphans) <span class="count" >({{$parent.variants.length}})</span></span>
     </label>
+  </div>
+  <div class="sort" >
+    Sort by:
+    <select ng-model="$parent.order.field">
+      <option value="name">name</option>
+      <option value="position">position</option>
+    </select>
+    &nbsp;
+    <select ng-model="$parent.order.reverse"
+      ng-options="o.value as o.label for o in $parent.sortOptions">
+    </select>
+  </div>
+  <div class="null-coord-note" ng-if="$parent.order.field === 'position' && $parent.nullCoordVars.length > 0">
+    Note: variant{{$parent.nullCoordVars.length > 1 ? 's' : ''}} <span ng-repeat="var in $parent.nullCoordVars">
+      {{$first ? '' : $last ? ($parent.nullCoordVars.length > 2 ? ', and ' : ' and ') : ', '}}
+    {{var}}</span> {{$parent.nullCoordVars.length > 1 ? 'have' : 'has'}} no sortable start coordinate.
   </div>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -131,9 +131,7 @@
   </div>
   <div class="row null-coord-note" ng-if="$parent.order.field === 'position' && $parent.nullCoordVars.length > 0">
     <div class="col-xs-12">
-      Note: variant{{$parent.nullCoordVars.length > 1 ? 's' : ''}} <span ng-repeat="var in $parent.nullCoordVars">
-      {{$first ? '' : $last ? ($parent.nullCoordVars.length > 2 ? ', and ' : ' and ') : ', '}}
-      {{var}}</span> {{$parent.nullCoordVars.length > 1 ? 'have' : 'has'}} no start coordinate, so will be placed at the end of the list.
+      Note: variant{{$parent.nullCoordVars.length > 1 ? 's' : ''}} <span ng-bind-html="$parent.nullCoordVars | arrayToList:5:'&hellip;':true | unsafe"></span> {{$parent.nullCoordVars.length > 1 ? 'have' : 'has'}} no start coordinate, so will be placed at the end of the list.
     </div>
   </div>
 </script>

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -11,7 +11,12 @@
         <input ng-model="query" class="form-control filter" placeholder="Filter by name" />
       </div>
       <div class="col-xs-2" style="text-align: right;">
-        <a uib-popover-template="'displayOptionsPopover.tpl.html'" popover-title="Variant Display Options" popover-trigger="'outsideClick'" popover-placement="left" popover-class="filters-content" class="btn btn-xs btn-default btn-block">
+        <a uib-popover-template="'displayOptionsPopover.tpl.html'"
+          popover-title="Variant Display Options"
+          popover-trigger="'outsideClick'"
+          popover-placement="left"
+          popover-class="filters-content"
+          class="btn btn-xs btn-default btn-block">
           <i class="glyphicon glyphicon-filter"></i>
           Display Options
         </a>
@@ -54,8 +59,8 @@
           ng-if="variant.statuses.pending_evidence_count > 0 || variant.statuses.open_change_count > 0"
           ng-class="{'pending-changes': variant.statuses.open_change_count > 0, 'pending-evidence': variant.statuses.pending_evidence_count > 0, 'pending-both': variant.statuses.open_change_count > 0 && variant.statuses.pending_evidence_count > 0}"></i>
         <span ng-bind-html="variant.name | highlightSearch:query" class="variant-name">Variant Name</span>
-    <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
-    </a>
+        <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
+      </a>
     </span>
   </script>
 
@@ -63,7 +68,7 @@
     <span>
       Evidence Items: {{ variant.evidence_item_statuses.accepted_count }}<br/>
       <span ng-if="variant.statuses.pending_evidence_count > 0" style="display: block;">Has {{ variant.statuses.pending_evidence_count }} pending evidence</span>
-    <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
+      <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
     </span>
   </script>
 

--- a/src/app/views/events/genes/summary/variantMenu.tpl.html
+++ b/src/app/views/events/genes/summary/variantMenu.tpl.html
@@ -7,15 +7,11 @@
           <span ng-if="variantGroups.length > 0">&amp; Variant Group{{variantGroups.length > 1 ? 's' : ''}}</span>
         </h4>
       </div>
-      <div class="col-xs-2" >
+      <div class="col-xs-2">
         <input ng-model="query" class="form-control filter" placeholder="Filter by name" />
       </div>
       <div class="col-xs-2" style="text-align: right;">
-        <a uib-popover-template="'displayOptionsPopover.tpl.html'"
-          popover-title="Variant Display Options"
-          popover-placement="left"
-          popover-class="filters-content"
-          class="btn btn-xs btn-default btn-block">
+        <a uib-popover-template="'displayOptionsPopover.tpl.html'" popover-title="Variant Display Options" popover-trigger="'outsideClick'" popover-placement="left" popover-class="filters-content" class="btn btn-xs btn-default btn-block">
           <i class="glyphicon glyphicon-filter"></i>
           Display Options
         </a>
@@ -58,8 +54,8 @@
           ng-if="variant.statuses.pending_evidence_count > 0 || variant.statuses.open_change_count > 0"
           ng-class="{'pending-changes': variant.statuses.open_change_count > 0, 'pending-evidence': variant.statuses.pending_evidence_count > 0, 'pending-both': variant.statuses.open_change_count > 0 && variant.statuses.pending_evidence_count > 0}"></i>
         <span ng-bind-html="variant.name | highlightSearch:query" class="variant-name">Variant Name</span>
-        <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
-      </a>
+    <span class="gene-name" ng-if="variant.multiGeneGroup">(<span ng-bind="variant.gene_entrez_name">Gene Name</span>)</span>
+    </a>
     </span>
   </script>
 
@@ -67,7 +63,7 @@
     <span>
       Evidence Items: {{ variant.evidence_item_statuses.accepted_count }}<br/>
       <span ng-if="variant.statuses.pending_evidence_count > 0" style="display: block;">Has {{ variant.statuses.pending_evidence_count }} pending evidence</span>
-      <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
+    <span ng-if="variant.statuses.open_change_count > 0" style="display: block;">Has {{ variant.statuses.open_change_count }} pending change{{variant.statuses.open_change_count > 1 ? 's' : '' }}</span>
     </span>
   </script>
 
@@ -88,44 +84,51 @@
 </div>
 
 <script type="text/ng-template" id="displayOptionsPopover.tpl.html">
-  <div class="radio">
-    <label>
-      <input type="radio" ng-model="$parent.options_filter" value="accepted">
-      <span uib-tooltip="Includes variants that have at least one editor-reviewed evidence item">Show variants with accepted evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
-    </label>
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="radio">
+        <label>
+          <input type="radio" ng-model="$parent.options_filter" value="accepted">
+          <span uib-tooltip="Includes variants that have at least one editor-reviewed evidence item">Show variants with accepted evidence <span class="count" >({{$parent.evidence_category_counts.accepted}})</span></span>
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="radio" ng-model="$parent.options_filter" value="accepted_submitted">
+          <span uib-tooltip="Includes variants that have at least one editor-reviewed and/or pending evidence item">Show variants with accepted and/or submitted evidence <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="radio" ng-model="$parent.options_filter" value="submitted">
+          <span uib-tooltip="Includes variants that have at least one item of evidence pending editor review">Show variants with submitted evidence <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="radio" ng-model="$parent.options_filter" value="all">
+          <span uib-tooltip="Includes all variants">Show all: variants with accepted, submitted, rejected, and/or no evidence (orphans) <span class="count" >({{$parent.variants.length}})</span></span>
+        </label>
+      </div>
+    </div>
   </div>
-  <div class="radio">
-    <label>
-      <input type="radio" ng-model="$parent.options_filter" value="accepted_submitted">
-      <span uib-tooltip="Includes variants that have at least one editor-reviewed and/or pending evidence item">Show variants with accepted and/or submitted evidence <span class="count" >({{$parent.evidence_category_counts.accepted + $parent.evidence_category_counts.submitted}})</span></span>
-    </label>
+  <div class="row" style="border-top: 1px solid #ccc; padding-top: 10px">
+    <div class="col-xs-12">
+      Sort by:
+      <select ng-model="$parent.order.field">
+        <option value="name">name</option>
+        <option value="position">position</option>
+      </select>
+      &nbsp;
+      <select ng-model="$parent.order.reverse" ng-options="o.value as o.label for o in $parent.sortOptions">
+      </select>
+    </div>
   </div>
-  <div class="radio">
-    <label>
-      <input type="radio" ng-model="$parent.options_filter" value="submitted">
-      <span uib-tooltip="Includes variants that have at least one item of evidence pending editor review">Show variants with submitted evidence <span class="count" >({{$parent.evidence_category_counts.submitted}})</span></span>
-    </label>
-  </div>
-  <div class="radio">
-    <label>
-      <input type="radio" ng-model="$parent.options_filter" value="all">
-      <span uib-tooltip="Includes all variants">Show all: variants with accepted, submitted, rejected, and/or no evidence (orphans) <span class="count" >({{$parent.variants.length}})</span></span>
-    </label>
-  </div>
-  <div class="sort" >
-    Sort by:
-    <select ng-model="$parent.order.field">
-      <option value="name">name</option>
-      <option value="position">position</option>
-    </select>
-    &nbsp;
-    <select ng-model="$parent.order.reverse"
-      ng-options="o.value as o.label for o in $parent.sortOptions">
-    </select>
-  </div>
-  <div class="null-coord-note" ng-if="$parent.order.field === 'position' && $parent.nullCoordVars.length > 0">
-    Note: variant{{$parent.nullCoordVars.length > 1 ? 's' : ''}} <span ng-repeat="var in $parent.nullCoordVars">
+  <div class="row null-coord-note" ng-if="$parent.order.field === 'position' && $parent.nullCoordVars.length > 0">
+    <div class="col-xs-12">
+      Note: variant{{$parent.nullCoordVars.length > 1 ? 's' : ''}} <span ng-repeat="var in $parent.nullCoordVars">
       {{$first ? '' : $last ? ($parent.nullCoordVars.length > 2 ? ', and ' : ' and ') : ', '}}
-    {{var}}</span> {{$parent.nullCoordVars.length > 1 ? 'have' : 'has'}} no sortable start coordinate.
+      {{var}}</span> {{$parent.nullCoordVars.length > 1 ? 'have' : 'has'}} no start coordinate, so will be placed at the end of the list.
+    </div>
   </div>
 </script>

--- a/src/app/views/events/variantGroups/summary/variantGrid.tpl.html
+++ b/src/app/views/events/variantGroups/summary/variantGrid.tpl.html
@@ -18,6 +18,7 @@
       <button
         class="btn btn-default btn-xs pull-right col-key btn-block"
         uib-popover-template="ctrl.exportPopover.templateUrl"
+        popover-trigger="'outsideClick'"
         ng-disabled="ctrl.variantGridOptions.data.length < 1"
         popover-placement="bottom">
         <span class="glyphicon glyphicon-export"

--- a/src/app/views/search/directives/queryBuilder.tpl.html
+++ b/src/app/views/search/directives/queryBuilder.tpl.html
@@ -101,10 +101,4 @@
       </div>
     </div>
   </div>
-  <!-- <div class="row"> -->
-  <!-- <div class="col-xs-12"> -->
-  <!-- <pre ng-bind="vm.model|json" ></pre> -->
-  <!-- </div> -->
-  <!-- </div> -->
-
 </div>

--- a/src/app/views/sources/components/cellTemplateActions.tpl.html
+++ b/src/app/views/sources/components/cellTemplateActions.tpl.html
@@ -1,43 +1,34 @@
 <div class="ui-grid-cell-contents" ng-controller="cellTemplateActionsController">
-  <span uib-tooltip="Add Evidence Item"
-        tooltip-append-to-body="true"
-        tooltip-enable="row.entity['status'] != 'rejected'">
+  <span uib-tooltip="Add Evidence Item" tooltip-append-to-body="true" tooltip-enable="row.entity['status'] != 'rejected'">
     <button ng-click="grid.appScope.vm.setLocation(row.entity.addEvidenceUrl)"
-            ng-disabled="row.entity['status'] != 'new' || !grid.appScope.vm.isAuthenticated()"
-            class="btn btn-xs btn-cell-add">
+      ng-disabled="row.entity['status'] != 'new' || !grid.appScope.vm.isAuthenticated()"
+      class="btn btn-xs btn-cell-add">
       <i class="glyphicon glyphicon-plus"></i>
     </button>
-  </span>
-  &nbsp;
-  <span uib-tooltip="Reject Suggestion"
-        tooltip-append-to-body="true"
-        tooltip-enable="row.entity['status'] != 'rejected'">
+  </span> &nbsp;
+  <span uib-tooltip="Reject Suggestion" tooltip-append-to-body="true" tooltip-enable="row.entity['status'] != 'rejected'">
     <button ng-disabled="row.entity['status'] != 'new' || !grid.appScope.vm.isAuthenticated()"
-            class="btn btn-xs btn-danger"
-            uib-popover-template="'rejectPopover.tpl.html'"
-            popover-is-open="popoverIsOpen"
-            popover-append-to-body="true"
-            popover-title="Reject Suggestion"
-            popover-placement="left">
+      class="btn btn-xs btn-danger"
+      uib-popover-template="'rejectPopover.tpl.html'"
+      popover-is-open="popoverIsOpen"
+      popover-trigger="'outsideClick'"
+      popover-append-to-body="true"
+      popover-title="Reject Suggestion"
+      popover-placement="left">
       <i class="glyphicon glyphicon-thumbs-down"></i>
     </button>
-  </span>
-  &nbsp;
-  <span uib-tooltip="Mark Suggestion as Curated"
-        tooltip-append-to-body="true"
-        tooltip-enable="row.entity['status'] != 'rejected'">
+  </span> &nbsp;
+  <span uib-tooltip="Mark Suggestion as Curated" tooltip-append-to-body="true" tooltip-enable="row.entity['status'] != 'rejected'">
     <button ng-click="grid.appScope.vm.setSuggestion(row.entity.id, 'curated')"
-            ng-disabled="row.entity['status'] != 'new' || !grid.appScope.vm.isAuthenticated()"
-            class="btn btn-xs btn-success">
+      ng-disabled="row.entity['status'] != 'new' || !grid.appScope.vm.isAuthenticated()"
+      class="btn btn-xs btn-success">
       <i class="glyphicon glyphicon-thumbs-up"></i>
     </button>
-  </span>
-  &nbsp;
-  <span uib-tooltip="Re-queue Suggestion"
-        tooltip-append-to-body="true">
+  </span> &nbsp;
+  <span uib-tooltip="Re-queue Suggestion" tooltip-append-to-body="true">
     <button ng-click="grid.appScope.vm.setSuggestion(row.entity.id, 'new')"
-            ng-disabled="row.entity['status'] === 'new' || !grid.appScope.vm.isAuthenticated()"
-            class="btn btn-xs btn-default">
+      ng-disabled="row.entity['status'] === 'new' || !grid.appScope.vm.isAuthenticated()"
+      class="btn btn-xs btn-default">
       <i class="glyphicon glyphicon-repeat"></i>
     </button>
   </span>
@@ -53,15 +44,15 @@
         </select>
       </div>
     </div>
-    <div class="row" >
+    <div class="row">
       <div class="col-xs-12 text-right" style="margin-top: .5em;">
         <button type="submit"
-                ng-click="rejectSuggestion(row.entity.id, 'rejected', reason)"
-                class="btn btn-xs btn-danger"
-                ng-click="ctrl.submit(ctrl.newFlag)"
-                ng-disabled="reason === 'none'"
-                uib-tooltip-enable="ctrl.newFlag.comment.text.length < 3"
-                uib-tooltip="Please add comment before submitting flag.">
+          ng-click="rejectSuggestion(row.entity.id, 'rejected', reason)"
+          class="btn btn-xs btn-danger"
+          ng-click="ctrl.submit(ctrl.newFlag)"
+          ng-disabled="reason === 'none'"
+          uib-tooltip-enable="ctrl.newFlag.comment.text.length < 3"
+          uib-tooltip="Please add comment before submitting flag.">
           Reject Suggestion
         </button>
       </div>

--- a/src/app/views/sources/components/sourceGrid.tpl.html
+++ b/src/app/views/sources/components/sourceGrid.tpl.html
@@ -18,6 +18,7 @@
       <button
         class="btn btn-default btn-xs pull-right col-key btn-block"
         uib-popover-template="ctrl.exportPopover.templateUrl"
+        popover-trigger="'outsideClick'"
         ng-disabled="ctrl.sourceGridOptions.data.length < 1"
         popover-placement="bottom">
         <span class="glyphicon glyphicon-export"


### PR DESCRIPTION
Sort options include 'name' and 'position'. Variants with no start position are placed at the end of the variant list (and a note appears describing this behavior to the user).

![screenshot 2018-10-30 12 08 11](https://user-images.githubusercontent.com/132909/47736963-d0437e00-dc3d-11e8-9c6c-88cd85279ce0.png)

Also, specified 'outsideClick' as the popover trigger for all popovers, thus allowing users to close the popover by clicking anywhere besides the popover itself. Previously it was required to click again a popover's buttton/link to close it.

