### PR TITLE
Add Variant advanced search by HGVS string

### DIFF
--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -2204,6 +2204,7 @@
                   { value: 'ensembl_version', name: 'Ensembl Version' },
                   { value: 'evidence_item_count', name: 'Evidence Items' },
                   { value: 'gene', name: 'Gene' },
+                  { value: 'hgvs_expressions', name: 'HGVS Expression(s)' },
                   { value: 'name', name: 'Name' },
                   { value: 'reference_bases', name: 'Reference Base(s)' },
                   { value: 'reference_build', name: 'Reference Build' },
@@ -2447,6 +2448,38 @@
                 type: 'input',
                 className: 'inline-field',
                 hideExpression: 'model.name === "is_empty"',
+                templateOptions: {
+                  label: '',
+                  required: true
+                }
+              }
+            ],
+            hgvs_expressions: [
+              {
+                key: 'name',
+                type: 'queryBuilderSelect',
+                className: 'inline-field',
+                data: {
+                  defaultValue: 'is'
+                },
+                templateOptions: {
+                  label: '',
+                  required: true,
+                  options: [
+                    {value: 'is', name: 'is'},
+                    {value: 'is_not', name: 'is not'},
+                    {value: 'contains', name: 'contains'},
+                    {value: 'begins_with', name: 'begins with'},
+                    {value: 'does_not_contain', name: 'does not contain'},
+                    {value: 'is_undefined', name: 'is undefined'}
+                  ]
+                }
+              },
+              {
+                key: 'parameters[0]',
+                type: 'input',
+                className: 'inline-field',
+                hideExpression: 'model.name === "is_undefined"',
                 templateOptions: {
                   label: '',
                   required: true

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -2402,7 +2402,7 @@
                     {value: 'contains', name: 'contains'},
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
-                    {value: 'none', name: 'none'}
+                    {value: 'is_undefined', name: 'is undefined'}
                   ]
                 }
               },
@@ -2410,7 +2410,7 @@
                 key: 'parameters[0]',
                 type: 'input',
                 className: 'inline-field',
-                hideExpression: 'model.name === "none"',
+                hideExpression: 'model.name === "is_undefined"',
                 templateOptions: {
                   label: '',
                   required: true
@@ -2470,7 +2470,7 @@
                     {value: 'contains', name: 'contains'},
                     {value: 'begins_with', name: 'begins with'},
                     {value: 'does_not_contain', name: 'does not contain'},
-                    {value: 'none', name: 'none'}
+                    {value: 'is_undefined', name: 'is undefined'}
                   ]
                 }
               },
@@ -2478,7 +2478,7 @@
                 key: 'parameters[0]',
                 type: 'input',
                 className: 'inline-field',
-                hideExpression: 'model.name === "none"',
+                hideExpression: 'model.name === "is_undefined"',
                 templateOptions: {
                   label: '',
                   required: true


### PR DESCRIPTION
Closes https://github.com/griffithlab/civic-client/issues/532

This PR also fixes an issue where we are using the `none` search operator, which was not defined on the server. I replaced those occurrences with `is_undefined`.