### PR TITLE
fixed flag service to accept and use request objects that include col sorting

### DIFF
--- a/src/components/services/FlagsService.js
+++ b/src/components/services/FlagsService.js
@@ -29,8 +29,8 @@
       queryOpen: queryOpen
     };
 
-    function queryOpen() {
-      return FlagsResource.queryOpen().$promise
+    function queryOpen(reqObj) {
+      return FlagsResource.queryOpen(reqObj).$promise
         .then(function(response) {
           angular.copy(response.records, collection);
           return response.$promise;


### PR DESCRIPTION
Flag service wasn't accepting request objects, so column sorting in the flag grid wasn't working properly.

Fixes #941 
Depends on griffithlab/civic-server#462
