### PR TITLE
Use API's author_string return value instead of re-constructing it

### DIFF
--- a/src/app/views/sources/components/sourceGrid.js
+++ b/src/app/views/sources/components/sourceGrid.js
@@ -103,7 +103,7 @@
           }
         },
         {
-          name: 'author_list_string',
+          name: 'author_string',
           displayName: 'Authors',
           enableFiltering: true,
           allowCellFocus: false,
@@ -201,14 +201,6 @@
 
           source.publication_date_string = pubDate.join('-');
 
-          // format author list
-          source.author_list_string = _(source.author_list)
-            .sortBy('position')
-            .map(function(author) {
-              return [author.fore_name, author.last_name].join(' ');
-            })
-            .value()
-            .join(', ');
           return source;
         });
       }


### PR DESCRIPTION
This will fix that the author is not being displayed for ASCO sources in
the advanced search results table.