### PR TITLE
organizations now show parent relationships where applicable

### DIFF
--- a/src/app/views/organizations/summary/organizationsSummary.less
+++ b/src/app/views/organizations/summary/organizationsSummary.less
@@ -7,6 +7,19 @@
   .users-rows .userCard {
     margin-bottom: @contentPadding;
   }
+  .org-parent {
+    font-size: 80%;
+    font-weight: normal;
+    color: #999;
+
+    a {
+      color: #999;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  }
   .org-image {
     min-height: 160px;
   }

--- a/src/app/views/organizations/summary/organizationsSummary.tpl.html
+++ b/src/app/views/organizations/summary/organizationsSummary.tpl.html
@@ -14,10 +14,21 @@
         <div class="panel-heading">
           <div class="row">
             <div class="col-xs-6">
-              <h3 style="margin: 0;padding: 0;">{{organization.name}}</h3>
+              <h3 style="margin: 0;padding: 0;">
+                {{organization.name}}
+                <span ng-if="organization.parent.id !== undefined">
+                  <span class="org-parent" >
+                    at
+                    <a ui-sref="organizations.summary({organizationId: organization.parent.id})">
+                      {{organization.parent.name}}
+                    </a>
+                  </span>
+                </span>
+              </h3>
             </div>
             <div class="col-xs-6 text-right">
-              <a class="btn btn-primary" target="_blank" href="{{organization.url}}" ng-bind="organization.url"></a>
+              <a ng-if="organization.url.length > 0"
+                class="btn btn-primary" target="_blank" href="{{organization.url}}" ng-bind="organization.url"></a>
             </div>
           </div>
         </div>
@@ -33,8 +44,8 @@
           <h4>Members</h4>
           <div class="row auto-clear users-rows">
             <user-card user="user"
-                       class="col-xs-6 col-sm-4 col-lg-3"
-                       ng-repeat="user in organization.members|orderBy:'id'">
+              class="col-xs-6 col-sm-4 col-lg-3"
+              ng-repeat="user in organization.members|orderBy:'id'">
             </user-card>
           </div>
           <div class="row" >
@@ -59,10 +70,10 @@
                       <tr>
                         <td class="key">Applied Revisions:</td>
                         <td class="value">{{stats.applied_changes}}</td>
-                      <tr>
-                        <td class="key">Suggested Sources:</td>
-                        <td class="value">{{stats.suggested_sources}}</td>
-                      </tr>
+                        <tr>
+                          <td class="key">Suggested Sources:</td>
+                          <td class="value">{{stats.suggested_sources}}</td>
+                        </tr>
                       </tr>
                     </table>
                   </div>

--- a/src/app/views/users/common/userSummary.less
+++ b/src/app/views/users/common/userSummary.less
@@ -48,6 +48,11 @@
     .value {
       color: @civicYellow;
       width: 50%;
+
+      a {
+        color: @civicYellow;
+        text-decoration: underline;
+      }
     }
 
     caption, tbody, tfoot, thead, tr, th, td {

--- a/src/app/views/users/common/userSummary.tpl.html
+++ b/src/app/views/users/common/userSummary.tpl.html
@@ -36,13 +36,24 @@
               </tr>
               <tr>
                 <td class="key">Organization:</td>
-                <td class="value" ng-if="user.organization.name == undefined">
-                  --
-                </td>
                 <td class="value">
-                  <a ui-sref="organizations.summary({organizationId: user.organization.id})">
-                    {{user.organization.name|ifEmpty: '--'}}
-                  </a>
+                  <span ng-switch="user.organization.id !== undefined">
+                    <!-- org obj -->
+                    <span ng-switch-when="true" >
+                      <a ui-sref="organizations.summary({organizationId: user.organization.id})">
+                        {{ user.organization.name }}</a>
+                      <!-- show parent org if exists -->
+                      <span ng-if="user.organization.parent.id !== undefined" >
+                        &nbsp;at <a ui-sref="organizations.summary({organizationId: user.organization.parent.id})">
+                        {{ user.organization.parent.name }}
+                        </a>
+                      </span>
+                    </span>
+                    <!-- no org obj -->
+                    <span ng-switch-when="false" >
+                      --
+                    </span>
+                  </span>
                 </td>
               </tr>
               <tr ng-if="user.bio.length > 0">

--- a/src/components/directives/organizationCard.tpl.html
+++ b/src/components/directives/organizationCard.tpl.html
@@ -10,23 +10,11 @@
   </div>
   <div class="row" >
     <div class="col-xs-12 organization-link" >
-        <a ui-sref="organizations.summary({organizationId: vm.organization.id})"><span ng-bind="vm.organization.name" class="card-name"></span></a>
-    </div>
-  </div>
-  <div class="row" ng-if="vm.organization.organization.name != undefined">
-    <div class="col-xs-12">
-      <div class="secondary-organization-attributes">
-        <ul>
-          <li class="attr-key">
-            Organization
-          </li>
-          <li class="attr-value">
-            <a ui-sref="organizations.summary({organizationId: vm.organization.organization.id})">
-            {{vm.organization.organization.name|ifEmpty: '--'}}
-          </a>
-          </li>
-        </ul>
-      </div>
+      <a ui-sref="organizations.summary({organizationId: vm.organization.id})"><span ng-bind="vm.organization.name" class="card-name"></span></a>
+      <span ng-if="vm.organization.parent.id !== undefined" >
+        at
+        <a ui-sref="organizations.summary({organizationId: vm.organization.parent.id})"><span ng-bind="vm.organization.parent.name" class="card-name"></span></a>
+      </span>
     </div>
   </div>
   <div class="row" ng-if="vm.organization.community_params !== undefined">


### PR DESCRIPTION
Organization summaries, cards, and on the user card now show parent relationships thusly: '[Organization] at [Organization Parent]'

![screenshot 2019-02-19 15 33 45](https://user-images.githubusercontent.com/132909/53054227-55f76d80-3469-11e9-955f-0b0239b14b02.png)
![screenshot 2019-02-19 16 04 10](https://user-images.githubusercontent.com/132909/53054234-5b54b800-3469-11e9-86b8-1db9b7024bc4.png)

