### PR TITLE
Use journal database field instead of full_journal_title

### DIFF
--- a/src/app/views/sources/components/sourceGrid.js
+++ b/src/app/views/sources/components/sourceGrid.js
@@ -124,7 +124,7 @@
           width: '10%'
         },
         {
-          name: 'full_journal_title',
+          name: 'journal',
           displayName: 'Journal',
           type: 'string',
           enableFiltering: true,


### PR DESCRIPTION
The ASCO journal information is only stored in the `journal` field, since it is abbreviated and a long form is not returned by the ASCO API. Switching to using the `journal` database field will have the result of showing ASCO journal information in the Source browse and advanced search tables.

As a side effect, the PubMed journal will now shop up in it's abbreviated form since that is what is stored in the `journal` field but I think that's ok.

Closes #1068 