### PR TITLE
assertion browse grid and summary page now show additional warnings

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -289,7 +289,8 @@
           allowCellFocus: false,
           filter: {
             condition: uiGridConstants.filter.CONTAINS
-          }
+          },
+          cellTemplate: 'app/views/events/common/assertionGrid/assertionGridEvidenceCell.tpl.html'
         }
       ],
       'evidence_items': [

--- a/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
+++ b/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
@@ -1,10 +1,19 @@
 <div class="assertionsSummaryCmp">
   <div class="row">
     <div class="col-xs-12 col-md-6">
+      <!-- status warnings -->
       <div class="row" ng-if="vm.assertion.status !== 'accepted'">
         <div class="col-xs-12 notices">
-          <div class="label label-warning" ng-if="vm.assertion.status === 'submitted'">This Assertion is under active curation and may be incomplete!</div>
+          <div class="label label-warning" ng-if="vm.assertion.status === 'submitted'">CAUTION: This Assertion has not been accepted as accurate or complete!</div>
           <div class="label label-danger" ng-if="vm.assertion.status === 'rejected'">WARNING: This Assertion has been rejected!</div>
+        </div>
+      </div>
+      <!-- attribute warnings -->
+      <div class="row" ng-if="vm.assertion.status !== 'accepted'">
+        <div class="col-xs-12 notices">
+          <div class="label label-danger" ng-if="vm.assertion.evidence_items.length === 0">WARNING: This Assertion has not been assigned any supporting Evidence!</div>
+          <div class="label label-warning" ng-if="vm.assertion.amp_level === null">CAUTION: This Assertion has not been assigned an AMP Category!</div>
+
         </div>
       </div>
       <div class="row">
@@ -84,10 +93,10 @@
                   {{ vm.assertion.drug_interaction_type }}
                 </td>
               </tr>
-              <tr ng-if="vm.assertion.amp_level.length > 0">
+              <tr>
                 <td class="key">AMP Category:</td>
                 <td class="value">
-                  {{ vm.assertion.amp_level }}
+                  {{ vm.assertion.amp_level | ifEmpty: '--' }}
                 </td>
               </tr>
               <tr ng-if="vm.assertion.acmg_codes.length > 0">

--- a/src/app/views/events/common/assertionGrid/assertionGridEvidenceCell.tpl.html
+++ b/src/app/views/events/common/assertionGrid/assertionGridEvidenceCell.tpl.html
@@ -1,0 +1,7 @@
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()">
+  {{ row.entity[col.field] }}
+  <span ng-if="row.entity[col.field] == 0">
+    &nbsp;<i class="glyphicon glyphicon-exclamation-sign" style="color: #942830"
+            uib-tooltip="Assertion has zero evidence and is likely under active curation."></i>
+  </span>
+</div>


### PR DESCRIPTION
- warning on browse grid if zero evidence
- warnings on assertion summary if zero evidence or no AMP category

Closes #1110.

![Screenshot 2019-07-16 11 59 14](https://user-images.githubusercontent.com/132909/61314614-a7125000-a7c2-11e9-923c-d5f223bc6369.png)
![Screenshot 2019-07-16 10 45 25](https://user-images.githubusercontent.com/132909/61314626-aaa5d700-a7c2-11e9-974b-7b33c9863b0b.png)
![Screenshot 2019-07-16 10 38 53](https://user-images.githubusercontent.com/132909/61314629-ac6f9a80-a7c2-11e9-89da-70a18c490373.png)
