### PR TITLE
add evidence form URLs w/o sourceId now properly prefill source fields

### DIFF
--- a/src/app/views/add/evidence/AddEvidenceController.js
+++ b/src/app/views/add/evidence/AddEvidenceController.js
@@ -19,7 +19,7 @@
         controllerAs: 'vm'
       })
       .state('add.evidence.basic', {
-        url: '/basic?geneId&variantId&geneName&variantName&diseaseName&pubmedId&sourceType&sourceId&variantOrigin&evidenceType&evidenceDirection&evidenceLevel&clinicalSignificance&isSuggestedSource',
+        url: '/basic?geneId&variantId&geneName&variantName&diseaseName&pubmedId&sourceType&sourceId&citationId&variantOrigin&evidenceType&evidenceDirection&evidenceLevel&clinicalSignificance&isSuggestedSource',
         template: '<add-evidence-basic></add-evidence-basic>',
         data: {
           titleExp: '"Add Evidence"',

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -300,14 +300,6 @@
           if($stateParams.citationId) {
             $scope.model.source.citation_id = $stateParams.citationId;
           }
-          // if($stateParams.sourceId) {
-          //   // get citation
-          //   Sources.get($stateParams.sourceId)
-          //     .then(function(response){
-          //       $scope.model.source = response;
-          //       $scope.to.data.citation = response.citation;
-          //     });
-          // }
         },
         expressionProperties: {
           'templateOptions.disabled': 'to.data.sourceType === "" || to.data.sourceType === undefined',

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -212,7 +212,7 @@
             var st = $stateParams.sourceType;
             var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.source_type);
             if(_.includes(permitted, st)) {
-              $scope.model.source_type = st;
+              $scope.model.source.source_type = st;
               $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[st];
               // update source field info
               // this unfortunately reproduces code in onChange below, but updating value above doesn't trigger onChange...
@@ -297,14 +297,17 @@
           }
         },
         controller: /* @ngInject */ function($scope, $stateParams) {
-          if($stateParams.sourceId) {
-            // get citation
-            Sources.get($stateParams.sourceId)
-              .then(function(response){
-                $scope.model.source = response;
-                $scope.to.data.citation = response.citation;
-              });
+          if($stateParams.citationId) {
+            $scope.model.source.citation_id = $stateParams.citationId;
           }
+          // if($stateParams.sourceId) {
+          //   // get citation
+          //   Sources.get($stateParams.sourceId)
+          //     .then(function(response){
+          //       $scope.model.source = response;
+          //       $scope.to.data.citation = response.citation;
+          //     });
+          // }
         },
         expressionProperties: {
           'templateOptions.disabled': 'to.data.sourceType === "" || to.data.sourceType === undefined',


### PR DESCRIPTION
Updates to source schema caused add evidence form URL pre-fill to break when querying URLs w/o a sourceId (like the ones we've autogenerated for various spreadsheets). This update fixes the form to properly prefill the source type and citation id fields.

Closes #1114. 