### PR TITLE
clingen allele registry IDs named '_:CA' are now displayed with a tooltip that describes them as 'unregistered'

### DIFF
--- a/src/app/views/events/variants/summary/variantSummary.js
+++ b/src/app/views/events/variants/summary/variantSummary.js
@@ -65,9 +65,6 @@
         });
       }
 
-      // treat '_:CA' values from registry as null, for now
-      if(variant.allele_registry_id === '_:CA') { variant.allele_registry_id = null; }
-
       return variant;
     }
   }

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -17,7 +17,18 @@
               </p>
             </div>
             <div ng-if="variant.allele_registry_id !== null" ng-class="{'col-xs-5': variant.allele_registry_id !== null , 'col-xs-12': variant.variant_aliases.length === 0 }">
-              <p><strong>Allele Registry ID: </strong> <a ng-href="https://reg.genome.network/allele/{{variant.allele_registry_id}}.html" target="_blank">{{variant.allele_registry_id}}</a></p>
+              <p><strong>Allele Registry ID: </strong>
+                <span ng-switch="variant.allele_registry_id">
+                  <span ng-switch-when="_:CA">
+                    <a ng-href="http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/landing"
+                      target="_blank"
+                      uib-tooltip="Allele not registered with ClinGen. Click to sign up with ClinGen and register it.">{{variant.allele_registry_id}}</a>
+                  </span>
+                  <span ng-switch-default>
+                    <a ng-href="https://reg.genome.network/allele/{{variant.allele_registry_id}}.html" target="_blank">{{variant.allele_registry_id}}</a>
+                  </span>
+                </span>
+              </p>
             </div>
           </div>
         </div>

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -20,9 +20,9 @@
               <p><strong>Allele Registry ID: </strong>
                 <span ng-switch="variant.allele_registry_id">
                   <span ng-switch-when="_:CA">
-                    <a ng-href="http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/landing"
+                    <a ng-href="http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/allele?hgvs={{variant.allele_registry_hgvs}}"
                       target="_blank"
-                      uib-tooltip="Allele not registered with ClinGen. Click to sign up with ClinGen and register it.">{{variant.allele_registry_id}}</a>
+                      uib-tooltip="Allele does not appear to be registered. Click to view its page and obtain a canonical allele identifier from ClinGen.">{{variant.allele_registry_id}}</a>
                   </span>
                   <span ng-switch-default>
                     <a ng-href="https://reg.genome.network/allele/{{variant.allele_registry_id}}.html" target="_blank">{{variant.allele_registry_id}}</a>


### PR DESCRIPTION
Previously allele registry IDs named '\_:CA' were changed to 'null', so the Allele Registry ID attribute was not shown for these variants. Now, the '\_:CA' allele registry ID is shown, and linked to the [ClinGen landing page](http://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/landing) (which contains instructions for signing up to register an allele ID). A tooltip is also displayed to help explain what's going on:

![Screenshot 2019-07-23 15 41 10](https://user-images.githubusercontent.com/132909/61748064-f0cfdd00-ad64-11e9-9c64-20c4ba21804e.png)

Closes #1131.

Requires server PR [#151](https://github.com/griffithlab/civic-server/pull/515).